### PR TITLE
Re-factor ScheduledConsumer - enable messageProvider injection

### DIFF
--- a/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/HashedEventIdentifierServiceImpl.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/HashedEventIdentifierServiceImpl.java
@@ -1,0 +1,77 @@
+/*
+ * $Id$
+ * $URL$
+ * 
+ * ====================================================================
+ * Ikasan Enterprise Integration Platform
+ * 
+ * Distributed under the Modified BSD License.
+ * Copyright notice: The copyright for this software and a full listing 
+ * of individual contributors are as shown in the packaged copyright.txt 
+ * file. 
+ * 
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice, 
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice, 
+ *    this list of conditions and the following disclaimer in the documentation 
+ *    and/or other materials provided with the distribution.
+ *
+ *  - Neither the name of the ORGANIZATION nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software without 
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE 
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ */
+package org.ikasan.component.endpoint.quartz;
+
+import org.apache.log4j.Logger;
+import org.ikasan.spec.event.ManagedEventIdentifierService;
+
+
+
+/**
+ * Implementation of the HashedEventIdentifierServiceImpl available for any type of message.
+ * Uses hashCode of a message as identifier.
+ *
+ * @author Ikasan Development Team
+ */
+public class HashedEventIdentifierServiceImpl<T> implements ManagedEventIdentifierService<String, T>
+{
+    /**
+     * class logger
+     */
+    private static Logger logger = Logger.getLogger(HashedEventIdentifierServiceImpl.class);
+
+    /*
+     * (non-Javadoc)
+     * @see org.ikasan.spec.event.EventLifeIdentifierService#getLifeIdentifier(java.lang.Object)
+     */
+    public String getEventIdentifier(T message)
+    {
+        return String.valueOf(message.hashCode());
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.ikasan.spec.event.EventLifeIdentifierService#setLifeIdentifier(java.lang.Object, java.lang.Object)
+     */
+    public void setEventIdentifier(String identifier, T message)
+    {
+    }
+}

--- a/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/MessageProvider.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/MessageProvider.java
@@ -1,0 +1,59 @@
+/* 
+ * $Id$
+ * $URL$
+ *
+ * ====================================================================
+ * Ikasan Enterprise Integration Platform
+ * 
+ * Distributed under the Modified BSD License.
+ * Copyright notice: The copyright for this software and a full listing 
+ * of individual contributors are as shown in the packaged copyright.txt 
+ * file. 
+ * 
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice, 
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice, 
+ *    this list of conditions and the following disclaimer in the documentation 
+ *    and/or other materials provided with the distribution.
+ *
+ *  - Neither the name of the ORGANIZATION nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software without 
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE 
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ */
+package org.ikasan.component.endpoint.quartz.consumer;
+
+import org.quartz.JobExecutionContext;
+
+/**
+ * This generic Message provider Interface invoked by Quartz scheduler.
+ *
+ * @author Ikasan Development Team
+ */
+public interface MessageProvider<T>
+{
+    /**
+     * Invokes the underlying tech implementation of message provider.
+     *
+     * @param context
+     * @return
+     */
+    T invoke(JobExecutionContext context);
+}

--- a/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/QuartzMessageProvider.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/QuartzMessageProvider.java
@@ -1,0 +1,57 @@
+/* 
+ * $Id$
+ * $URL$
+ *
+ * ====================================================================
+ * Ikasan Enterprise Integration Platform
+ * 
+ * Distributed under the Modified BSD License.
+ * Copyright notice: The copyright for this software and a full listing 
+ * of individual contributors are as shown in the packaged copyright.txt 
+ * file. 
+ * 
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice, 
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice, 
+ *    this list of conditions and the following disclaimer in the documentation 
+ *    and/or other materials provided with the distribution.
+ *
+ *  - Neither the name of the ORGANIZATION nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software without 
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE 
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ */
+package org.ikasan.component.endpoint.quartz.consumer;
+
+import org.quartz.JobExecutionContext;
+
+/**
+ * Default implementation on MessageProvider using JobExecutionContext as a message type.
+ * 
+ * @author Ikasan Development Team
+ */
+public class QuartzMessageProvider implements MessageProvider<JobExecutionContext>
+{
+    @Override
+    public JobExecutionContext invoke(JobExecutionContext context)
+    {
+        return context;
+    }
+}


### PR DESCRIPTION
Re-factoring of ScheduledConsumer in order to enable flexible reuse of the consumer. 
Following were added:
- managedEventIdentifierService property to allow injection of different implementations of ManagedEventIdentifierService
- messageProvider property - to allow injection of different TechEndpoints
