### PR TITLE
IKASAN-770 - Enable correct AOP pointcut on ScheduleConsumer

### DIFF
--- a/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumer.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumer.java
@@ -80,11 +80,6 @@ public class ScheduledConsumer<T>
     private Scheduler scheduler;
 
     /**
-     * scheduled job factory
-     */
-    private ScheduledJobFactory scheduledJobFactory;
-
-    /**
      * consumer event factory
      */
     private EventFactory<FlowEvent<?, ?>> flowEventFactory;
@@ -113,14 +108,9 @@ public class ScheduledConsumer<T>
     private boolean criticalOnStartup;
 
     /**
-     * job identifying name
+     * job detail wired by spring config.
      */
-    private String name;
-
-    /**
-     * job identifying group
-     */
-    private String group;
+    private JobDetail jobDetail;
 
     /**
      * default messageProvider is set to QuartzMessageProvider - can be overridden via the setter
@@ -133,31 +123,13 @@ public class ScheduledConsumer<T>
      * Constructor
      *
      * @param scheduler
-     * @param scheduledJobFactory
-     * @param name
-     * @param group
      */
-    public ScheduledConsumer(Scheduler scheduler, ScheduledJobFactory scheduledJobFactory, String name, String group)
+    public ScheduledConsumer(Scheduler scheduler)
     {
         this.scheduler = scheduler;
         if (scheduler == null)
         {
             throw new IllegalArgumentException("scheduler cannot be 'null'");
-        }
-        this.scheduledJobFactory = scheduledJobFactory;
-        if (scheduledJobFactory == null)
-        {
-            throw new IllegalArgumentException("scheduledJobFactory cannot be 'null'");
-        }
-        this.name = name;
-        if (name == null)
-        {
-            throw new IllegalArgumentException("name cannot be 'null'");
-        }
-        this.group = group;
-        if (group == null)
-        {
-            throw new IllegalArgumentException("group cannot be 'null'");
         }
     }
 
@@ -168,7 +140,6 @@ public class ScheduledConsumer<T>
     {
         try
         {
-            JobDetail jobDetail = scheduledJobFactory.createJobDetail(this, this.name, this.group);
             // create trigger
             // TODO - allow configuration to support multiple triggers
             JobKey jobkey = jobDetail.getKey();
@@ -196,7 +167,7 @@ public class ScheduledConsumer<T>
     {
         try
         {
-            JobKey jobKey = new JobKey(name, group);
+            JobKey jobKey = jobDetail.getKey();
             if (this.scheduler.checkExists(jobKey))
             {
                 this.scheduler.deleteJob(jobKey);
@@ -221,7 +192,7 @@ public class ScheduledConsumer<T>
             {
                 return false;
             }
-            JobKey jobKey = new JobKey(this.name, this.group);
+            JobKey jobKey = jobDetail.getKey();
             if (this.scheduler.checkExists(jobKey))
             {
                 return true;
@@ -391,5 +362,10 @@ public class ScheduledConsumer<T>
     public void setCriticalOnStartup(boolean criticalOnStartup)
     {
         this.criticalOnStartup = criticalOnStartup;
+    }
+
+    public void setJobDetail(JobDetail jobDetail)
+    {
+        this.jobDetail = jobDetail;
     }
 }

--- a/ikasaneip/component/endpoint/quartz-schedule/src/test/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumerTest.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/test/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumerTest.java
@@ -81,9 +81,6 @@ public class ScheduledConsumerTest
     /** Mock scheduler */
     final Scheduler scheduler = mockery.mock(Scheduler.class, "mockScheduler");
 
-    /** Mock scheduled job factory */
-    final ScheduledJobFactory scheduledJobFactory = mockery.mock(ScheduledJobFactory.class, "mockScheduledJobFactory");
-
     /** Mock job detail */
     final JobDetail mockJobDetail = mockery.mock(JobDetail.class, "mockJobDetail");
 
@@ -112,34 +109,7 @@ public class ScheduledConsumerTest
     @Test(expected = IllegalArgumentException.class)
     public void test_failed_constructorDueToNullScheduler()
     {
-        new ScheduledConsumer(null, null, null, null);
-    }
-
-    /**
-     * Test failed constructor for scheduled consumer due to null flowEventFactory.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void test_failed_constructorDueToNullFlowEventFactory()
-    {
-        new ScheduledConsumer(scheduler, null, null, null);
-    }
-
-    /**
-     * Test failed constructor for scheduled consumer due to null name.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void test_failed_constructorDueToNullName()
-    {
-        new ScheduledConsumer(scheduler, scheduledJobFactory, null, null);
-    }
-
-    /**
-     * Test failed constructor for scheduled consumer due to null group.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void test_failed_constructorDueToNullGroup()
-    {
-        new ScheduledConsumer(scheduler, scheduledJobFactory, "name", null);
+        new ScheduledConsumer(null);
     }
 
     /**
@@ -155,9 +125,6 @@ public class ScheduledConsumerTest
         mockery.checking(new Expectations()
         {
             {
-                exactly(1).of(scheduledJobFactory).createJobDetail(with(any(Job.class)), with(any(String.class)), with(any(String.class)));
-                will(returnValue(mockJobDetail));
-
                 // get flow and module name from the job
                 exactly(1).of(mockJobDetail).getKey();
                 will(returnValue(jobKey));
@@ -172,8 +139,9 @@ public class ScheduledConsumerTest
             }
         });
 
-        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler, scheduledJobFactory, "flowName", "moduleName");
+        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler);
         scheduledConsumer.setConfiguration(consumerConfiguration);
+        scheduledConsumer.setJobDetail(mockJobDetail);
         scheduledConsumer.start();
         mockery.assertIsSatisfied();
     }
@@ -191,9 +159,6 @@ public class ScheduledConsumerTest
         mockery.checking(new Expectations()
         {
             {
-                exactly(1).of(scheduledJobFactory).createJobDetail(with(any(Job.class)), with(any(String.class)), with(any(String.class)));
-                will(returnValue(mockJobDetail));
-
                 // get flow and module name from the job
                 exactly(1).of(mockJobDetail).getKey();
                 will(returnValue(jobKey));
@@ -208,7 +173,7 @@ public class ScheduledConsumerTest
             }
         });
 
-        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler, scheduledJobFactory, "flowName", "moduleName");
+        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler);
         scheduledConsumer.setConfiguration(consumerConfiguration);
         scheduledConsumer.start();
         mockery.assertIsSatisfied();
@@ -227,9 +192,6 @@ public class ScheduledConsumerTest
         mockery.checking(new Expectations()
         {
             {
-                exactly(1).of(scheduledJobFactory).createJobDetail(with(any(Job.class)), with(any(String.class)), with(any(String.class)));
-                will(returnValue(mockJobDetail));
-
                 // get flow and module name from the job
                 exactly(1).of(mockJobDetail).getKey();
                 will(returnValue(jobKey));
@@ -244,7 +206,7 @@ public class ScheduledConsumerTest
             }
         });
 
-        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler, scheduledJobFactory, "flowName", "moduleName");
+        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler);
         scheduledConsumer.setConfiguration(consumerConfiguration);
         scheduledConsumer.start();
         mockery.assertIsSatisfied();
@@ -265,6 +227,9 @@ public class ScheduledConsumerTest
         mockery.checking(new Expectations()
         {
             {
+                exactly(1).of(mockJobDetail).getKey();
+                will(returnValue(jobKey));
+
                 // unschedule the job
                 exactly(1).of(scheduler).checkExists(jobKey);
                 will(returnValue(Boolean.TRUE));
@@ -273,8 +238,9 @@ public class ScheduledConsumerTest
             }
         });
 
-        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler, scheduledJobFactory, "flowName", "moduleName");
+        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler);
         scheduledConsumer.setConfiguration(consumerConfiguration);
+        scheduledConsumer.setJobDetail(mockJobDetail);
         scheduledConsumer.stop();
         mockery.assertIsSatisfied();
     }
@@ -305,7 +271,7 @@ public class ScheduledConsumerTest
             }
         });
 
-        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler, scheduledJobFactory, "flowName", "moduleName");
+        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler);
         scheduledConsumer.setConfiguration(consumerConfiguration);
         scheduledConsumer.stop();
         mockery.assertIsSatisfied();
@@ -333,7 +299,7 @@ public class ScheduledConsumerTest
             }
         });
 
-        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler, scheduledJobFactory, "flowName", "moduleName");
+        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler);
         scheduledConsumer.setEventFactory(flowEventFactory);
         scheduledConsumer.setEventListener(eventListener);
         scheduledConsumer.setManagedEventIdentifierService(mockManagedEventIdentifierService);
@@ -368,7 +334,7 @@ public class ScheduledConsumerTest
             }
         });
 
-        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler, scheduledJobFactory, "flowName", "moduleName");
+        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler);
         scheduledConsumer.setEventFactory(flowEventFactory);
         scheduledConsumer.setEventListener(eventListener);
         scheduledConsumer.setManagedEventIdentifierService(mockManagedEventIdentifierService);
@@ -406,7 +372,7 @@ public class ScheduledConsumerTest
             }
         });
 
-        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler, scheduledJobFactory, "flowName", "moduleName");
+        ScheduledConsumer scheduledConsumer = new StubbedScheduledConsumer(scheduler);
         
         scheduledConsumer.setEventFactory(flowEventFactory);
         scheduledConsumer.setEventListener(eventListener);
@@ -427,9 +393,9 @@ public class ScheduledConsumerTest
      */
     private class StubbedScheduledConsumer extends ScheduledConsumer
     {
-        protected StubbedScheduledConsumer(Scheduler scheduler, ScheduledJobFactory scheduledJobFactory, String name, String group)
+        protected StubbedScheduledConsumer(Scheduler scheduler)
         {
-            super(scheduler, scheduledJobFactory, name, group);
+            super(scheduler);
         }
         
         @Override


### PR DESCRIPTION
Enable correct AOP pointcut on ScheduleConsumer by injecting jobDetail instead of using  scheduledJobFactory to create job detail.