### PR TITLE
IKASAN-761: Added default support for dynamicConfiguration persistence

### DIFF
--- a/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/visitorPattern/AbstractFlowConfiguration.java
+++ b/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/visitorPattern/AbstractFlowConfiguration.java
@@ -144,6 +144,12 @@ public class AbstractFlowConfiguration
     {
         this.configurationService.configure(configuredResource);
     }
+    
+  
+    public void update(DynamicConfiguredResource configuredResource)
+    {
+        this.configurationService.update(configuredResource);
+    }
 
     public List<FlowElement<?>> getFlowElements()
     {

--- a/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/visitorPattern/FlowConfiguration.java
+++ b/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/visitorPattern/FlowConfiguration.java
@@ -68,4 +68,11 @@ public interface FlowConfiguration
      * @param configuredResource
      */
     public void configure(ConfiguredResource configuredResource);
+    
+    /**
+     * Allow for the saving of a DynamicConfiguredResources changed configuration
+     * 
+     * @param dynamicConfiguredResource
+     */
+    public void update(DynamicConfiguredResource dynamicConfiguredResource);
 }

--- a/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/visitorPattern/VisitingInvokerFlow.java
+++ b/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/visitorPattern/VisitingInvokerFlow.java
@@ -564,24 +564,14 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
             }
             else
             {
-                for(FlowElement<DynamicConfiguredResource> flowElement:this.flowConfiguration.getDynamicConfiguredResourceFlowElements())
-                {
-                    try
-                    {
-                        this.flowConfiguration.configure(flowElement.getFlowComponent());
-                    }
-                    catch(RuntimeException e)
-                    {
-                        flowInvocationContext.addInvokedComponentName(flowElement.getComponentName());
-                        throw e;
-                    }
-                }
-
+                configureDynamicConfiguredResources(flowInvocationContext);
                 invoke(moduleName, name, flowInvocationContext, event, this.flowConfiguration.getConsumerFlowElement());
+                updateDynamicConfiguredResources(flowInvocationContext);
                 if(this.recoveryManager.isRecovering())
                 {
                     this.recoveryManager.cancel();
                 }
+                
             }
         }
         catch(Throwable throwable)
@@ -591,6 +581,38 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
         finally
         {
             this.notifyMonitor();
+        }
+    }
+
+    private void configureDynamicConfiguredResources(FlowInvocationContext flowInvocationContext)
+    {
+        for(FlowElement<DynamicConfiguredResource> flowElement:this.flowConfiguration.getDynamicConfiguredResourceFlowElements())
+        {
+            try
+            {
+                this.flowConfiguration.configure(flowElement.getFlowComponent());
+            }
+            catch(RuntimeException e)
+            {
+                flowInvocationContext.addInvokedComponentName(flowElement.getComponentName());
+                throw e;
+            }
+        }
+    }
+    
+    private void updateDynamicConfiguredResources(FlowInvocationContext flowInvocationContext)
+    {
+        for(FlowElement<DynamicConfiguredResource> flowElement:this.flowConfiguration.getDynamicConfiguredResourceFlowElements())
+        {
+            try
+            {
+                this.flowConfiguration.update(flowElement.getFlowComponent());
+            }
+            catch(RuntimeException e)
+            {
+                flowInvocationContext.addInvokedComponentName(flowElement.getComponentName());
+                throw e;
+            }
         }
     }
 

--- a/ikasaneip/flow/visitorPatternFlow/src/test/java/org/ikasan/flow/visitorPattern/VisitingInvokerFlowTest.java
+++ b/ikasaneip/flow/visitorPatternFlow/src/test/java/org/ikasan/flow/visitorPattern/VisitingInvokerFlowTest.java
@@ -160,6 +160,9 @@ public class VisitingInvokerFlowTest
     /** mock managed resource */
     final ConfiguredResource configuredResource = mockery.mock(ConfiguredResource.class, "mockConfiguredResource");
 
+    /** mock managed resource */
+    final DynamicConfiguredResource dynamicConfiguredResource = mockery.mock(DynamicConfiguredResource.class, "mockDynamicConfiguredResource");
+
     /** Mock consumer flowElement */
     final FlowElement<Consumer<EventListener<FlowEvent<?,?>>,EventFactory>> consumerFlowElement
             = mockery.mock(FlowElement.class, "mockConsumerFlowElement");
@@ -1963,9 +1966,9 @@ public class VisitingInvokerFlowTest
                 will(returnIterator(dynamicConfiguredResourceFlowElement, dynamicConfiguredResourceFlowElement));
 
                 exactly(2).of(dynamicConfiguredResourceFlowElement).getFlowComponent();
-                will(returnValue(configuredResource));
+                will(returnValue(dynamicConfiguredResource));
 
-                exactly(2).of(flowConfiguration).configure(configuredResource);
+                exactly(2).of(flowConfiguration).configure(dynamicConfiguredResource);
 
                 one(flowConfiguration).getConsumerFlowElement();
                 will(returnValue(consumerFlowElement));
@@ -1977,6 +1980,16 @@ public class VisitingInvokerFlowTest
                 exactly(1).of(exclusionService).isBlackListed(flowEvent);
                 will(returnValue(false));
 
+                one(flowConfiguration).getDynamicConfiguredResourceFlowElements();
+                will(returnValue(dynamicConfiguredResourceFlowElements));
+                one(dynamicConfiguredResourceFlowElements).iterator();
+                will(returnIterator(dynamicConfiguredResourceFlowElement, dynamicConfiguredResourceFlowElement));
+
+                exactly(2).of(dynamicConfiguredResourceFlowElement).getFlowComponent();
+                will(returnValue(dynamicConfiguredResource));
+
+                exactly(2).of(flowConfiguration).update(dynamicConfiguredResource);
+                
                 // in this test we do not need to cancel recovery
                 one(recoveryManager).isRecovering();
                 will(returnValue(false));


### PR DESCRIPTION
within the flow

- The VisitingInvokerFlow will now update the dynamic configured
resource afer the flow has been invoked
- Updated associated test

@mitcje you requested a review of this - please pull if happy.