### PR TITLE
Ikasan 853 - Revert mvn deployment from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,24 @@ jdk:
   - oraclejdk7
 install: true
 script:  
-  - mvn clean test -Dmaven.javadoc.skip=true -B -V
+  - echo "<settings><servers><server><id>ikasaneip-snapshots</id><username>\${env.OSS_IKASAN_USER}</username><password>\${env.OSS_IKASAN_PASS}</password></server></servers><activeProfiles><activeProfile>securecentral</activeProfile></activeProfiles><profiles><profile><id>securecentral</id><repositories> <repository><id>ikasaneip-snapshots</id><url>http://oss.sonatype.org/content/repositories/snapshots/</url><releases><enabled>false</enabled></releases><snapshots><enabled>true</enabled></snapshots></repository><repository><id>ikasaneip-releases</id><url>http://oss.sonatype.org/content/repositories/releases/</url><releases><enabled>true</enabled></releases><snapshots><enabled>false</enabled></snapshots></repository>		<repository><id>central</id><url>https://repo1.maven.org/maven2</url><releases><enabled>true</enabled></releases></repository></repositories><pluginRepositories><pluginRepository><id>central</id><url>https://repo1.maven.org/maven2</url><releases><enabled>true</enabled></releases></pluginRepository></pluginRepositories></profile></profiles></settings>" > ~/settings.xml
+  - mvn clean test -Dmaven.javadoc.skip=true -B -V --settings ~/settings.xml;
 cache:
   directories:
   - $HOME/.m2
+
+
+<repositories>
+   <repository>
+            <id>ikasaneip-snapshots</id>
+            <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
+          </repository>
+          <repository>
+            <id>ikasaneip-releases</id>
+            <url>http://oss.sonatype.org/content/repositories/releases/</url>
+          </repository>
+          <repository>
+            <id>ikasaneip-releases</id>
+            <url>http://repo.maven.apache.org/maven2</url>
+          </repository>
+            </repositories>

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,3 @@ script:
 cache:
   directories:
   - $HOME/.m2
-
-
-<repositories>
-   <repository>
-            <id>ikasaneip-snapshots</id>
-            <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
-          </repository>
-          <repository>
-            <id>ikasaneip-releases</id>
-            <url>http://oss.sonatype.org/content/repositories/releases/</url>
-          </repository>
-          <repository>
-            <id>ikasaneip-releases</id>
-            <url>http://repo.maven.apache.org/maven2</url>
-          </repository>
-            </repositories>

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ jdk:
   - oraclejdk7
 install: true
 script:  
-  - echo "<settings><servers><server><id>ikasaneip-snapshots</id><username>\${env.OSS_IKASAN_USER}</username><password>\${env.OSS_IKASAN_PASS}</password></server></servers></settings>" > ~/settings.xml
-  - mvn clean test -Dmaven.javadoc.skip=true -B -V --settings ~/settings.xml;
+  - mvn clean test -Dmaven.javadoc.skip=true -B -V
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ jdk:
 install: true
 script:  
   - echo "<settings><servers><server><id>ikasaneip-snapshots</id><username>\${env.OSS_IKASAN_USER}</username><password>\${env.OSS_IKASAN_PASS}</password></server></servers></settings>" > ~/settings.xml
-  - "[[ $TRAVIS_BRANCH == \"master\" ]] && { mvn -Pcore-and-components clean deploy -Dmaven.javadoc.skip=true -B -V --settings ~/settings.xml; };"
-  - "[[ $TRAVIS_BRANCH == \"master\" ]] && { mvn -Ptop-level-services-and-applications clean deploy -Dmaven.javadoc.skip=true -B -V --settings ~/settings.xml; };"
-  - "[[ $TRAVIS_BRANCH != \"master\" ]] && { mvn clean install -Dmaven.javadoc.skip=true -B -V --settings ~/settings.xml; };"
+  - mvn clean test -Dmaven.javadoc.skip=true -B -V --settings ~/settings.xml;
 cache:
   directories:
   - $HOME/.m2


### PR DESCRIPTION
At the moment the mvn deployment from travisci is not working. I am proposing to revert it back to a working state where TravisCI is just running just mvn test. That will ensure that branches/pull request are in good state at least. Lets investigate travisCI and mvn deploys later on.