### PR TITLE
Travis build failure fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install: true
 script:  
   - echo "<settings><servers><server><id>ikasaneip-snapshots</id><username>\${env.OSS_IKASAN_USER}</username><password>\${env.OSS_IKASAN_PASS}</password></server></servers><activeProfiles><activeProfile>securecentral</activeProfile></activeProfiles><profiles><profile><id>securecentral</id><repositories> <repository><id>ikasaneip-snapshots</id><url>http://oss.sonatype.org/content/repositories/snapshots/</url><releases><enabled>false</enabled></releases><snapshots><enabled>true</enabled></snapshots></repository><repository><id>ikasaneip-releases</id><url>http://oss.sonatype.org/content/repositories/releases/</url><releases><enabled>true</enabled></releases><snapshots><enabled>false</enabled></snapshots></repository>		<repository><id>central</id><url>https://repo1.maven.org/maven2</url><releases><enabled>true</enabled></releases></repository></repositories><pluginRepositories><pluginRepository><id>central</id><url>https://repo1.maven.org/maven2</url><releases><enabled>true</enabled></releases></pluginRepository></pluginRepositories></profile></profiles></settings>" > ~/settings.xml
   - cd ikasaneip
-  - mvn clean test -Dmaven.javadoc.skip=true -B -V --settings ~/settings.xml;
+  - mvn clean test -Dmaven.javadoc.skip=true -U -B -V --settings ~/settings.xml;
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ jdk:
 install: true
 script:  
   - echo "<settings><servers><server><id>ikasaneip-snapshots</id><username>\${env.OSS_IKASAN_USER}</username><password>\${env.OSS_IKASAN_PASS}</password></server></servers><activeProfiles><activeProfile>securecentral</activeProfile></activeProfiles><profiles><profile><id>securecentral</id><repositories> <repository><id>ikasaneip-snapshots</id><url>http://oss.sonatype.org/content/repositories/snapshots/</url><releases><enabled>false</enabled></releases><snapshots><enabled>true</enabled></snapshots></repository><repository><id>ikasaneip-releases</id><url>http://oss.sonatype.org/content/repositories/releases/</url><releases><enabled>true</enabled></releases><snapshots><enabled>false</enabled></snapshots></repository>		<repository><id>central</id><url>https://repo1.maven.org/maven2</url><releases><enabled>true</enabled></releases></repository></repositories><pluginRepositories><pluginRepository><id>central</id><url>https://repo1.maven.org/maven2</url><releases><enabled>true</enabled></releases></pluginRepository></pluginRepositories></profile></profiles></settings>" > ~/settings.xml
+  - cd ikasaneip
   - mvn clean test -Dmaven.javadoc.skip=true -B -V --settings ~/settings.xml;
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install: true
 script:  
   - echo "<settings><servers><server><id>ikasaneip-snapshots</id><username>\${env.OSS_IKASAN_USER}</username><password>\${env.OSS_IKASAN_PASS}</password></server></servers><activeProfiles><activeProfile>securecentral</activeProfile></activeProfiles><profiles><profile><id>securecentral</id><repositories> <repository><id>ikasaneip-snapshots</id><url>http://oss.sonatype.org/content/repositories/snapshots/</url><releases><enabled>false</enabled></releases><snapshots><enabled>true</enabled></snapshots></repository><repository><id>ikasaneip-releases</id><url>http://oss.sonatype.org/content/repositories/releases/</url><releases><enabled>true</enabled></releases><snapshots><enabled>false</enabled></snapshots></repository>		<repository><id>central</id><url>https://repo1.maven.org/maven2</url><releases><enabled>true</enabled></releases></repository></repositories><pluginRepositories><pluginRepository><id>central</id><url>https://repo1.maven.org/maven2</url><releases><enabled>true</enabled></releases></pluginRepository></pluginRepositories></profile></profiles></settings>" > ~/settings.xml
   - cd ikasaneip
-  - mvn clean test -Dmaven.javadoc.skip=true -U -B -V --settings ~/settings.xml;
+  - mvn clean install -Dmaven.javadoc.skip=true -U -B -V --settings ~/settings.xml;
 cache:
   directories:
   - $HOME/.m2

--- a/ikasaneip/.travis.yml
+++ b/ikasaneip/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: java
 jdk:
   - oraclejdk7


### PR DESCRIPTION
Manage to figure out what is going on with ikasan-webconsole-skinny-war.

ikasan-webconsole-skinny-war dependes on ikasan-webconsole-war, you cant run just 'mvn clean test' cause ikasan-webconsole-war does not exist in repository at the exceution time.