### PR TITLE
IKASAN-919 - Fix issues with OlderFirstClientListEntryComparator

### DIFF
--- a/ikasaneip/filetransfer/connector-basefiletransfer/src/main/java/org/ikasan/connector/basefiletransfer/net/OlderFirstClientListEntryComparator.java
+++ b/ikasaneip/filetransfer/connector-basefiletransfer/src/main/java/org/ikasan/connector/basefiletransfer/net/OlderFirstClientListEntryComparator.java
@@ -46,27 +46,26 @@ import java.util.Comparator;
  * <code>OlderFirstClientListEntryComparator</code> is an implementation of
  * {@link Comparator} for <code>ClientListEntry</code> that compares two such
  * objects based on their last modified dates.
- * 
- * @author Ikasan Development Team 
- * 
+ *
+ * @author Ikasan Development Team
  */
 public class OlderFirstClientListEntryComparator implements Comparator<ClientListEntry>
 {
     public int compare(ClientListEntry cle1, ClientListEntry cle2)
     {
-        boolean older = cle1.getMtime() < cle2.getMtime();
-        boolean newer = cle1.getMtime() > cle2.getMtime();
-        if (older && newer)
+        int mtimeComparison = new Long(cle1.getMtime()).compareTo(new Long(cle2.getMtime()));
+        if (mtimeComparison == 0)
         {
-            return 0;
-        }
-        else if (newer)
-        {
-            return 1;
+            if(cle1.getName()!=null&&cle2.getName()!=null)
+                return cle1.getName().compareTo(cle2.getName());
+            else{
+                return -1;
+            }
+
         }
         else
         {
-            return -1;
+            return mtimeComparison;
         }
     }
 }

--- a/ikasaneip/filetransfer/connector-basefiletransfer/src/test/java/org/ikasan/connector/basefiletransfer/net/OlderFirstClientListEntryComparatorListTest.java
+++ b/ikasaneip/filetransfer/connector-basefiletransfer/src/test/java/org/ikasan/connector/basefiletransfer/net/OlderFirstClientListEntryComparatorListTest.java
@@ -1,0 +1,142 @@
+/*
+ * $Id:$
+ * $URL:$
+ *
+ * ====================================================================
+ * Ikasan Enterprise Integration Platform
+ *
+ * Distributed under the Modified BSD License.
+ * Copyright notice: The copyright for this software and a full listing
+ * of individual contributors are as shown in the packaged copyright.txt
+ * file.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  - Neither the name of the ORGANIZATION nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ */
+package org.ikasan.connector.basefiletransfer.net;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Tests OlderFirstClientListEntryComparator
+ */
+public class OlderFirstClientListEntryComparatorListTest
+{
+    private OlderFirstClientListEntryComparator uut = new OlderFirstClientListEntryComparator();
+
+    @Test
+    public void compare_when_firstfile_is_older(){
+        ClientListEntry firstClientListEntry =new ClientListEntry();
+        firstClientListEntry.setMtime(1438155532);
+        firstClientListEntry.setName("A");
+        ClientListEntry secondClientListEntry =new ClientListEntry();
+        secondClientListEntry.setMtime(1439155532);
+        secondClientListEntry.setName("B");
+
+        List<ClientListEntry> list = new ArrayList<ClientListEntry>();
+        list.add(firstClientListEntry);
+        list.add(secondClientListEntry);
+
+        //do test
+        Collections.sort(list, uut);
+
+        assertEquals("A", list.get(0).getName());
+        assertEquals("B", list.get(1).getName());
+
+    }
+
+    @Test
+    public void compare_when_secondfile_is_older(){
+        ClientListEntry firstClientListEntry =new ClientListEntry();
+        firstClientListEntry.setMtime(1439155532);
+        firstClientListEntry.setName("A");
+        ClientListEntry secondClientListEntry =new ClientListEntry();
+        secondClientListEntry.setMtime(1438155532);
+        secondClientListEntry.setName("B");
+
+        List<ClientListEntry> list = new ArrayList<ClientListEntry>();
+        list.add(firstClientListEntry);
+        list.add(secondClientListEntry);
+
+        //do test
+        Collections.sort(list, uut);
+
+        assertEquals("B", list.get(0).getName());
+        assertEquals("A", list.get(1).getName());
+
+    }
+
+    @Test
+    public void compare_when_files_have_same_age(){
+        ClientListEntry firstClientListEntry =new ClientListEntry();
+        firstClientListEntry.setMtime(1439155532);
+        firstClientListEntry.setName("A");
+        ClientListEntry secondClientListEntry =new ClientListEntry();
+        secondClientListEntry.setMtime(1439155532);
+        secondClientListEntry.setName("B");
+
+        List<ClientListEntry> list = new ArrayList<ClientListEntry>();
+        list.add(firstClientListEntry);
+        list.add(secondClientListEntry);
+
+        //do test
+        Collections.sort(list, uut);
+
+        assertEquals("A", list.get(0).getName());
+        assertEquals("B", list.get(1).getName());
+
+    }
+
+    @Test
+    public void compare_when_files_have_same_age_and_same_name(){
+        ClientListEntry firstClientListEntry =new ClientListEntry();
+        firstClientListEntry.setMtime(1439155532);
+        firstClientListEntry.setName("A");
+        ClientListEntry secondClientListEntry =new ClientListEntry();
+        secondClientListEntry.setMtime(1439155532);
+        secondClientListEntry.setName("A");
+
+        List<ClientListEntry> list = new ArrayList<ClientListEntry>();
+        list.add(firstClientListEntry);
+        list.add(secondClientListEntry);
+
+        //do test
+        Collections.sort(list, uut);
+
+        assertEquals("A", list.get(0).getName());
+        assertEquals("A", list.get(1).getName());
+
+    }
+}

--- a/ikasaneip/filetransfer/connector-basefiletransfer/src/test/java/org/ikasan/connector/basefiletransfer/net/OlderFirstClientListEntryComparatorTest.java
+++ b/ikasaneip/filetransfer/connector-basefiletransfer/src/test/java/org/ikasan/connector/basefiletransfer/net/OlderFirstClientListEntryComparatorTest.java
@@ -1,0 +1,98 @@
+/*
+ * $Id:$
+ * $URL:$
+ *
+ * ====================================================================
+ * Ikasan Enterprise Integration Platform
+ *
+ * Distributed under the Modified BSD License.
+ * Copyright notice: The copyright for this software and a full listing
+ * of individual contributors are as shown in the packaged copyright.txt
+ * file.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  - Neither the name of the ORGANIZATION nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ */
+package org.ikasan.connector.basefiletransfer.net;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Tests OlderFirstClientListEntryComparator
+ */
+public class OlderFirstClientListEntryComparatorTest
+{
+    private OlderFirstClientListEntryComparator uut = new OlderFirstClientListEntryComparator();
+
+    @Test
+    public void compare_when_firstCEL_is_older(){
+        ClientListEntry firstClientListEntry =new ClientListEntry();
+        firstClientListEntry.setMtime(1438155532);
+        firstClientListEntry.setName("A");
+        ClientListEntry secondClientListEntry =new ClientListEntry();
+        secondClientListEntry.setMtime(1439155532);
+        secondClientListEntry.setName("B");
+
+        int result = uut.compare(firstClientListEntry,secondClientListEntry);
+
+        assertEquals(-1,result);
+
+    }
+
+    @Test
+    public void compare_when_secondCEL_is_older(){
+        ClientListEntry firstClientListEntry =new ClientListEntry();
+        firstClientListEntry.setMtime(1439155532);
+        firstClientListEntry.setName("A");
+        ClientListEntry secondClientListEntry =new ClientListEntry();
+        secondClientListEntry.setMtime(1438155532);
+        secondClientListEntry.setName("B");
+
+        int result = uut.compare(firstClientListEntry,secondClientListEntry);
+
+        assertEquals(1,result);
+
+    }
+
+    @Test
+    public void compare_when_file_have_same_age(){
+        ClientListEntry firstClientListEntry =new ClientListEntry();
+        firstClientListEntry.setMtime(1439155532);
+        firstClientListEntry.setName("A");
+        ClientListEntry secondClientListEntry =new ClientListEntry();
+        secondClientListEntry.setMtime(1439155532);
+        secondClientListEntry.setName("B");
+
+        int result = uut.compare(firstClientListEntry,secondClientListEntry);
+
+        assertEquals(-1,result);
+
+    }
+}


### PR DESCRIPTION
Fix for SFTP and FTP consumers have a problem with retrieving files in chronological order when files in were created at exactly the same time.

