### PR TITLE
1.0.x Re-instate maxRetries recovery / code cleanup

### DIFF
--- a/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumer.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumer.java
@@ -277,10 +277,10 @@ public class ScheduledConsumer<T>
             }
 
             // only start this consumer if its not currently running or purposefully paused.
-//            if(!this.isRunning() && !this.isPaused())
-//            {
-//                this.start();
-//            }
+            if(!this.isRunning() && !this.isPaused())
+            {
+                this.start();
+            }
         }
     }
 

--- a/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumer.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumer.java
@@ -56,6 +56,7 @@ import org.ikasan.spec.event.EventListener;
 import org.ikasan.spec.event.ForceTransactionRollbackException;
 import org.ikasan.spec.event.ManagedEventIdentifierService;
 import org.ikasan.spec.event.Resubmission;
+import org.ikasan.spec.flow.Flow;
 import org.ikasan.spec.flow.FlowEvent;
 import org.ikasan.spec.management.ManagedResource;
 import org.ikasan.spec.management.ManagedResourceRecoveryManager;
@@ -251,6 +252,8 @@ public class ScheduledConsumer<T>
      */
     public void invoke(T message)
     {
+        boolean isRecovering = managedResourceRecoveryManager.isRecovering();
+
         if (message != null)
         {
             FlowEvent<?, ?> flowEvent = createFlowEvent(message);
@@ -262,22 +265,49 @@ public class ScheduledConsumer<T>
             {
                 logger.debug("'null' returned from MessageProvider. Flow not invoked");
             }
+        }
 
+        if(isRecovering)
+        {
+            // cancel the recovery schedule if still active
+            // could be the flow has already cancelled this, so check
             if(managedResourceRecoveryManager.isRecovering())
             {
-                // cancel the recovery schedule
                 managedResourceRecoveryManager.cancel();
             }
+
+            // only start this consumer if its not currently running or purposefully paused.
+//            if(!this.isRunning() && !this.isPaused())
+//            {
+//                this.start();
+//            }
         }
     }
-    
+
+    /**
+     * Quick workaround to determine if this consumer has been stopped as part of a pause
+     * rather than stopped as part of a complete flow stop.
+     * @return
+     */
+    protected boolean isPaused()
+    {
+        if(eventListener instanceof Flow)
+        {
+            return ((Flow)eventListener).isPaused();
+        }
+
+        return false;
+    }
+
     /* (non-Javadoc)
 	 * @see org.ikasan.spec.resubmission.ResubmissionService#submit(java.lang.Object)
 	 */
 	@Override
 	public void submit(T event)
 	{
-		if (event != null)
+        boolean isRecovering = managedResourceRecoveryManager.isRecovering();
+
+        if (event != null)
         {
             FlowEvent<?, ?> flowEvent = createFlowEvent(event);
 
@@ -291,11 +321,21 @@ public class ScheduledConsumer<T>
             {
                 logger.debug("'null' returned from MessageProvider. Flow not invoked");
             }
+        }
 
+        if(isRecovering)
+        {
+            // cancel the recovery schedule if still active
+            // could be the flow has already cancelled this, so check
             if(managedResourceRecoveryManager.isRecovering())
             {
-                // cancel the recovery schedule
                 managedResourceRecoveryManager.cancel();
+            }
+
+            // only start this consumer if its not currently running or purposefully paused.
+            if(!this.isRunning() && !this.isPaused())
+            {
+                this.start();
             }
         }
 	}

--- a/ikasaneip/component/endpoint/quartz-schedule/src/test/java/org/ikasan/component/endpoint/quartz/consumer/CallbackMessageProviderImplTest.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/test/java/org/ikasan/component/endpoint/quartz/consumer/CallbackMessageProviderImplTest.java
@@ -137,7 +137,7 @@ public class CallbackMessageProviderImplTest
                 exactly(1).of(scheduler).scheduleJob(mockJobDetail, trigger);
                 will(returnValue(new Date()));
 
-                exactly(2).of(mockManagedResourceRecoveryManager).isRecovering();
+                exactly(3).of(mockManagedResourceRecoveryManager).isRecovering();
                 will(returnValue(false));
 
                 // create flowEvent and call flow

--- a/ikasaneip/component/endpoint/quartz-schedule/src/test/java/org/ikasan/component/endpoint/quartz/consumer/CallbackMessageProviderImplTest.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/test/java/org/ikasan/component/endpoint/quartz/consumer/CallbackMessageProviderImplTest.java
@@ -137,6 +137,9 @@ public class CallbackMessageProviderImplTest
                 exactly(1).of(scheduler).scheduleJob(mockJobDetail, trigger);
                 will(returnValue(new Date()));
 
+                exactly(2).of(mockManagedResourceRecoveryManager).isRecovering();
+                will(returnValue(false));
+
                 // create flowEvent and call flow
                 exactly(1).of(mockManagedEventIdentifierService).getEventIdentifier("one");
                 will(returnValue("1"));

--- a/ikasaneip/component/endpoint/quartz-schedule/src/test/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumerTest.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/test/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumerTest.java
@@ -291,6 +291,8 @@ public class ScheduledConsumerTest
         mockery.checking(new Expectations()
         {
             {
+                exactly(1).of(mockManagedResourceRecoveryManager).isRecovering();
+                will(returnValue(false));
 
                 // schedule the job
                 exactly(1).of(mockManagedEventIdentifierService).getEventIdentifier(jobExecutionContext);
@@ -311,6 +313,7 @@ public class ScheduledConsumerTest
         scheduledConsumer.setConfiguration(consumerConfiguration);
         scheduledConsumer.setEventFactory(flowEventFactory);
         scheduledConsumer.setEventListener(eventListener);
+        scheduledConsumer.setManagedResourceRecoveryManager(mockManagedResourceRecoveryManager);
         scheduledConsumer.setManagedEventIdentifierService(mockManagedEventIdentifierService);
         // test
         scheduledConsumer.execute(jobExecutionContext);
@@ -378,7 +381,7 @@ public class ScheduledConsumerTest
                 exactly(1).of(consumerConfiguration).isEager();
                 will(returnValue(false));
 
-                exactly(1).of(mockManagedResourceRecoveryManager).isRecovering();
+                exactly(2).of(mockManagedResourceRecoveryManager).isRecovering();
                 will(returnValue(true));
 
                 // cancel recovery
@@ -452,6 +455,8 @@ public class ScheduledConsumerTest
         mockery.checking(new Expectations()
         {
             {
+                exactly(1).of(mockManagedResourceRecoveryManager).isRecovering();
+                will(returnValue(false));
 
                 // schedule the job
                 exactly(1).of(mockManagedEventIdentifierService).getEventIdentifier(jobExecutionContext);
@@ -477,6 +482,7 @@ public class ScheduledConsumerTest
         scheduledConsumer.setEventFactory(flowEventFactory);
         scheduledConsumer.setEventListener(eventListener);
         scheduledConsumer.setManagedEventIdentifierService(mockManagedEventIdentifierService);
+        scheduledConsumer.setManagedResourceRecoveryManager(mockManagedResourceRecoveryManager);
         scheduledConsumer.setJobDetail(jobDetail);
 
         // test

--- a/ikasaneip/component/endpoint/quartz-schedule/src/test/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumerTest.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/test/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumerTest.java
@@ -160,8 +160,7 @@ public class ScheduledConsumerTest
         final JobKey jobKey = new JobKey("flowName", "moduleName");
         
         // expectations
-        mockery.checking(new Expectations()
-        {
+        mockery.checking(new Expectations() {
             {
                 // get flow and module name from the job
                 exactly(1).of(mockJobDetail).getKey();
@@ -170,7 +169,7 @@ public class ScheduledConsumerTest
                 // access configuration for details
                 exactly(1).of(consumerConfiguration).getCronExpression();
                 will(returnValue("* * * * ? ?"));
-                
+
                 // schedule the job
                 exactly(1).of(scheduler).scheduleJob(mockJobDetail, trigger);
                 will(throwException(new SchedulerException()));
@@ -259,8 +258,7 @@ public class ScheduledConsumerTest
         final JobKey jobKey = new JobKey("flowName", "moduleName");
         
         // expectations
-        mockery.checking(new Expectations()
-        {
+        mockery.checking(new Expectations() {
             {
                 // get flow and module name from the job
                 exactly(1).of(mockJobDetail).getKey();
@@ -339,7 +337,7 @@ public class ScheduledConsumerTest
                 exactly(0).of(mockManagedEventIdentifierService).getEventIdentifier(jobExecutionContext);
                 will(returnValue(identifier));
 
-                exactly(0).of(flowEventFactory).newEvent(identifier,jobExecutionContext);
+                exactly(0).of(flowEventFactory).newEvent(identifier, jobExecutionContext);
                 will(returnValue(mockFlowEvent));
 
                 exactly(0).of(eventListener).invoke(mockFlowEvent);
@@ -367,9 +365,10 @@ public class ScheduledConsumerTest
     }
 
     @Test
-    public void test_execute_when_messageProvider_message_is_null_when_in_recovery() throws SchedulerException
+    public void test_execute_when_messageProvider_message_is_null_when_in_recovery_and_reinstate_business_schedule() throws SchedulerException
     {
         final MessageProvider mockMessageProvider = mockery.mock( MessageProvider.class);
+        final JobKey jobKey = new JobKey("");
 
         // expectations
         mockery.checking(new Expectations()
@@ -386,6 +385,25 @@ public class ScheduledConsumerTest
 
                 // cancel recovery
                 exactly(1).of(mockManagedResourceRecoveryManager).cancel();
+
+                // nope, consumer is not running
+                exactly(1).of(scheduler).isShutdown();
+                will(returnValue(false));
+                exactly(1).of(scheduler).isInStandbyMode();
+                will(returnValue(false));
+                exactly(1).of(mockJobDetail).getKey();
+                will(returnValue(jobKey));
+                exactly(1).of(scheduler).checkExists(jobKey);
+                will(returnValue(false));
+
+                // start consumer
+                exactly(1).of(mockJobDetail).getKey();
+                will(returnValue(jobKey));
+                exactly(1).of(consumerConfiguration).getCronExpression();
+                will(returnValue("*"));
+                exactly(1).of(scheduler).scheduleJob(mockJobDetail, trigger);
+                will(returnValue(new Date()));
+
             }
         });
 

--- a/ikasaneip/configuration-service/src/test/java/com/company/mypackage/name/ExtendedSampleConfiguration.java
+++ b/ikasaneip/configuration-service/src/test/java/com/company/mypackage/name/ExtendedSampleConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * $Id$
+ * $URL$
+ *
+ * ====================================================================
+ * Ikasan Enterprise Integration Platform
+ *
+ * Distributed under the Modified BSD License.
+ * Copyright notice: The copyright for this software and a full listing
+ * of individual contributors are as shown in the packaged copyright.txt
+ * file.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  - Neither the name of the ORGANIZATION nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ */
+package com.company.mypackage.name;
+
+import org.ikasan.configurationService.service.SampleConfiguration;
+
+/**
+ * Extended Sample configuration class for testing
+ * Ikasan Development Team.
+ */
+public class ExtendedSampleConfiguration extends SampleConfiguration
+{
+	private String extendedField;
+
+	private boolean primitiveBool;
+
+	public String getExtendedField() {
+		return extendedField;
+	}
+
+	public void setExtendedField(String extendedField) {
+		this.extendedField = extendedField;
+	}
+
+	public boolean isPrimitiveBool() {
+		return primitiveBool;
+	}
+
+	public void setPrimitiveBool(boolean primitiveBool) {
+		this.primitiveBool = primitiveBool;
+	}
+}

--- a/ikasaneip/configuration-service/src/test/java/org/ikasan/configurationService/service/ConfiguredResourceConfigurationServiceTest.java
+++ b/ikasaneip/configuration-service/src/test/java/org/ikasan/configurationService/service/ConfiguredResourceConfigurationServiceTest.java
@@ -46,6 +46,7 @@ import java.util.Map;
 
 import javax.annotation.Resource;
 
+import com.company.mypackage.name.ExtendedSampleConfiguration;
 import org.ikasan.configurationService.dao.ConfigurationDao;
 import org.ikasan.configurationService.model.ConfigurationParameterMapImpl;
 import org.ikasan.configurationService.model.ConfigurationParameterStringImpl;
@@ -142,6 +143,47 @@ public class ConfiguredResourceConfigurationServiceTest
     public void test_configurationService_setting_of_a_static_configuration_with_configuration()
     {
         final SampleConfiguration runtimeConfiguration = new SampleConfiguration();
+        final Configuration<List<ConfigurationParameter>> persistedConfiguration = new DefaultConfiguration("configuredResourceId");
+
+        // add a string parameter
+        persistedConfiguration.getParameters().add( new ConfigurationParameterStringImpl("one", "1", "Number One") );
+
+        // save it
+        this.configurationServiceDao.save(persistedConfiguration);
+
+        // expectations
+        mockery.checking(new Expectations()
+        {
+            {
+                // once to try to locate a dao based on this id
+                one(configuredResource).getConfiguredResourceId();
+                will(returnValue("configuredResourceId"));
+
+                // once to try to locate a dao based on this id
+                one(configuredResource).getConfiguration();
+                will(returnValue(runtimeConfiguration));
+
+                // set the dao on the resource
+                one(configuredResource).setConfiguration(runtimeConfiguration);
+            }
+        });
+
+        configurationService.configure(configuredResource);
+        this.mockery.assertIsSatisfied();
+    }
+
+    /**
+     * Test the setting of a static dao on a configuredResource at runtime
+     * where a persisted dao exists.
+     * This is typically invoked on the start of a flow where the flow identifies
+     * all configuredResources and ensures the latest dao is applied
+     * prior to starting the moving components.
+     */
+    @Test
+    @DirtiesContext
+    public void test_configurationService_setting_of_a_static_configuration_with_configuration_extendedClass()
+    {
+        final ExtendedSampleConfiguration runtimeConfiguration = new ExtendedSampleConfiguration();
         final Configuration<List<ConfigurationParameter>> persistedConfiguration = new DefaultConfiguration("configuredResourceId");
 
         // add a string parameter

--- a/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/visitorPattern/VisitingInvokerFlow.java
+++ b/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/visitorPattern/VisitingInvokerFlow.java
@@ -450,7 +450,10 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
 
         try
         {
-            consumer.start();
+            if(!consumer.isRunning())
+            {
+                consumer.start();
+            }
         }
         catch(RuntimeException e)
         {
@@ -592,6 +595,9 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
                 if(this.recoveryManager.isRecovering())
                 {
                     this.recoveryManager.cancel();
+
+                    // start the consumer if not already running
+                    startConsumer();
                 }
                 
             }
@@ -622,6 +628,9 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
             if(this.recoveryManager.isRecovering())
             {
                 this.recoveryManager.cancel();
+
+                // start the consumer if not already running
+                startConsumer();
             }
                 
         }

--- a/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/visitorPattern/VisitingInvokerFlow.java
+++ b/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/visitorPattern/VisitingInvokerFlow.java
@@ -419,7 +419,11 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
         }
     }
 
-    protected boolean isRunning()
+    /**
+     * Is this flow in a running / recovering state
+     * @return
+     */
+    public boolean isRunning()
     {
         String currentState = this.getState();
         if(currentState.equals(RECOVERING) || currentState.equals(RUNNING))
@@ -429,7 +433,17 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
 
         return false;
     }
-    
+
+    /**
+     * Is this flow in a paused state
+     * @return
+     */
+    public boolean isPaused()
+    {
+        String currentState = this.getState();
+        return currentState.equals(PAUSED);
+    }
+
     /**
      * Start the consumer component.
      */
@@ -450,10 +464,7 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
 
         try
         {
-            if(!consumer.isRunning())
-            {
-                consumer.start();
-            }
+            consumer.start();
         }
         catch(RuntimeException e)
         {
@@ -595,11 +606,7 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
                 if(this.recoveryManager.isRecovering())
                 {
                     this.recoveryManager.cancel();
-
-                    // start the consumer if not already running
-                    startConsumer();
                 }
-                
             }
         }
         catch(Throwable throwable)
@@ -628,11 +635,7 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
             if(this.recoveryManager.isRecovering())
             {
                 this.recoveryManager.cancel();
-
-                // start the consumer if not already running
-                startConsumer();
             }
-                
         }
         catch(Throwable throwable)
         {

--- a/ikasaneip/recovery-manager/src/main/java/org/ikasan/recovery/ScheduledRecoveryManager.java
+++ b/ikasaneip/recovery-manager/src/main/java/org/ikasan/recovery/ScheduledRecoveryManager.java
@@ -246,21 +246,21 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
         {
             RetryAction retryAction = (RetryAction)action;
 
-            if(!this.consumer.isRunning())
-            {
-                // consumer has been paused or previously stopped for a reason,
-                // so do not allow the retry to reactivate the consumer.
-                // Just want to ensure any changes get rolled back.
-                if(this.isRecovering())
-                {
-                    this.cancelRecovery();
-                }
-
-                this.previousComponentName = componentName;
-                this.previousExceptionAction = retryAction;
-
-                throw new ForceTransactionRollbackException(action.toString() + " ignored on a paused/stopped consumer", throwable);
-            }
+//            if(!this.consumer.isRunning())
+//            {
+//                // consumer has been paused or previously stopped for a reason,
+//                // so do not allow the retry to reactivate the consumer.
+//                // Just want to ensure any changes get rolled back.
+//                if(this.isRecovering())
+//                {
+//                    this.cancelRecovery();
+//                }
+//
+//                this.previousComponentName = componentName;
+//                this.previousExceptionAction = retryAction;
+//
+//                throw new ForceTransactionRollbackException(action.toString() + " ignored on a paused/stopped consumer", throwable);
+//            }
 
             this.consumer.stop();
             stopManagedResources();
@@ -301,21 +301,21 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
         {
             ScheduledRetryAction scheduledRetryAction = (ScheduledRetryAction)action;
 
-            if(!this.consumer.isRunning())
-            {
-                // consumer has been paused or previously stopped for a reason,
-                // so do not allow the retry to reactivate the consumer.
-                // Just want to ensure any changes get rolled back.
-                if(this.isRecovering())
-                {
-                    this.cancelRecovery();
-                }
-
-                this.previousComponentName = componentName;
-                this.previousExceptionAction = scheduledRetryAction;
-
-                throw new ForceTransactionRollbackException(action.toString() + " ignoring retry on a paused/stopped consumer.", throwable);
-            }
+//            if(!this.consumer.isRunning())
+//            {
+//                // consumer has been paused or previously stopped for a reason,
+//                // so do not allow the retry to reactivate the consumer.
+//                // Just want to ensure any changes get rolled back.
+//                if(this.isRecovering())
+//                {
+//                    this.cancelRecovery();
+//                }
+//
+//                this.previousComponentName = componentName;
+//                this.previousExceptionAction = scheduledRetryAction;
+//
+//                throw new ForceTransactionRollbackException(action.toString() + " ignoring retry on a paused/stopped consumer.", throwable);
+//            }
 
             this.consumer.stop();
             stopManagedResources();
@@ -537,12 +537,6 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
     public void cancel()
     {
         this.cancelRecovery();
-
-//        // for scheduled based consumers we need start them on their normal flow of execution
-//        if(this.consumer instanceof Job)
-//        {
-//            this.consumer.start();
-//        }
     }
     
     public void initialise()

--- a/ikasaneip/recovery-manager/src/main/java/org/ikasan/recovery/ScheduledRecoveryManager.java
+++ b/ikasaneip/recovery-manager/src/main/java/org/ikasan/recovery/ScheduledRecoveryManager.java
@@ -532,18 +532,17 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
     }
 
     /**
-     * Cancel an in progress recovery and restore any scheduled consumers.
-     * This is a workaround to scheduled consumers being a bit of an odd ball in the consumer world.
+     * Cancel an in progress recovery.
      */
     public void cancel()
     {
         this.cancelRecovery();
 
-        // for scheduled based consumers we need start them on their normal flow of execution
-        if(this.consumer instanceof Job)
-        {
-            this.consumer.start();
-        }
+//        // for scheduled based consumers we need start them on their normal flow of execution
+//        if(this.consumer instanceof Job)
+//        {
+//            this.consumer.start();
+//        }
     }
     
     public void initialise()

--- a/ikasaneip/spec/flow/src/main/java/org/ikasan/spec/flow/Flow.java
+++ b/ikasaneip/spec/flow/src/main/java/org/ikasan/spec/flow/Flow.java
@@ -142,4 +142,16 @@ public interface Flow
      * @return
      */
     public SerialiserFactory getSerialiserFactory();
+
+    /**
+     * Is this flow in a running state
+     * @return
+     */
+    public boolean isRunning();
+
+    /**
+     * Is this flow in a paused state
+     * @return
+     */
+    public boolean isPaused();
 }


### PR DESCRIPTION
Reverts the change undertaken for not going into recovery when a consumer is paused for all non-scheduled consumers. Scheduled consumer still has this function