### PR TITLE
Resolve the following deployment exception by adding back missing comma.

### DIFF
--- a/ikasaneip/developer/mvn-archetype/ikasan-jboss-6-sftp-im/src/main/resources/archetype-resources/ear/pom.xml
+++ b/ikasaneip/developer/mvn-archetype/ikasan-jboss-6-sftp-im/src/main/resources/archetype-resources/ear/pom.xml
@@ -36,7 +36,7 @@
 							<Dependencies>deployment.${artifactId}-ear-${project.version}.ear,
                                 org.ikasan.${dashed.ikasan.version}.configuration,
 								${groupId}.${artifactId}.${dashed.project.version}.conf,
-								org.ikasan.${dashed.ikasan.version}.sftp.ra
+								org.ikasan.${dashed.ikasan.version}.sftp.ra,
                                 javax.servlet.jsp.api,javax.servlet.jstl.api,javax.servlet.api, org.apache.log4j,
 								org.hornetq, org.jboss.remote-naming, org.jboss.msc, org.jboss.as.naming
 							</Dependencies>


### PR DESCRIPTION
JBAS018733: Failed to process phase PARSE of deployment
IllegalArgumentException: Module name contains invalid characters, or
empty segments
