### PR TITLE
IKASAN-1263 -  fix equals and hashCode method for Role And Policy 

### DIFF
--- a/ikasaneip/security/src/main/java/org/ikasan/security/model/Policy.java
+++ b/ikasaneip/security/src/main/java/org/ikasan/security/model/Policy.java
@@ -217,12 +217,7 @@ public class Policy implements GrantedAuthority, Comparable<Policy>
     {
         final int prime = 31;
         int result = 1;
-        result = prime * result
-                + ((description == null) ? 0 : description.hashCode());
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
         result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result
-                + ((policyLink == null) ? 0 : policyLink.hashCode());
         return result;
 
     }

--- a/ikasaneip/security/src/main/java/org/ikasan/security/model/Role.java
+++ b/ikasaneip/security/src/main/java/org/ikasan/security/model/Role.java
@@ -197,9 +197,6 @@ public class Role implements Comparable<Role>
     {
         final int prime = 31;
         int result = 1;
-        result = prime * result
-                + ((description == null) ? 0 : description.hashCode());
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
         result = prime * result + ((name == null) ? 0 : name.hashCode());
         return result;
     }


### PR DESCRIPTION
IKASAN-1263 -  fix equals and hashCode method for Role And Policy to only use Name rather then name and description