### PR TITLE
1.4.x-IKASAN-1245 Recovery Manager multi-threaded consumer fixes

### DIFF
--- a/ikasaneip/component/endpoint/jms-client/src/main/java/org/ikasan/component/endpoint/jms/consumer/GenericJmsConsumer.java
+++ b/ikasaneip/component/endpoint/jms-client/src/main/java/org/ikasan/component/endpoint/jms/consumer/GenericJmsConsumer.java
@@ -40,29 +40,28 @@
  */
 package org.ikasan.component.endpoint.jms.consumer;
 
-import java.util.*;
-
-import javax.jms.*;
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-
 import org.apache.log4j.Logger;
 import org.ikasan.component.endpoint.jms.DestinationResolver;
 import org.ikasan.component.endpoint.jms.JmsEventIdentifierServiceImpl;
 import org.ikasan.spec.component.endpoint.Consumer;
 import org.ikasan.spec.component.endpoint.EndpointListener;
+import org.ikasan.spec.component.endpoint.MultiThreadedCapable;
 import org.ikasan.spec.component.transformation.Converter;
 import org.ikasan.spec.component.transformation.TransformationException;
 import org.ikasan.spec.configuration.ConfiguredResource;
 import org.ikasan.spec.event.EventFactory;
 import org.ikasan.spec.event.EventListener;
-import org.ikasan.spec.event.ManagedEventIdentifierException;
 import org.ikasan.spec.event.ManagedEventIdentifierService;
 import org.ikasan.spec.event.Resubmission;
 import org.ikasan.spec.flow.FlowEvent;
 import org.ikasan.spec.management.ManagedIdentifierService;
 import org.ikasan.spec.resubmission.ResubmissionService;
+
+import javax.jms.*;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Hashtable;
 
 /**
  * Implementation of a generic client consumer based on the JMS specification.
@@ -72,7 +71,7 @@ import org.ikasan.spec.resubmission.ResubmissionService;
 public class GenericJmsConsumer 
     implements Consumer<EventListener<?>,EventFactory>,
         ManagedIdentifierService<ManagedEventIdentifierService>, EndpointListener<Message,Throwable>,
-        ConfiguredResource<GenericJmsConsumerConfiguration>, ResubmissionService<Message>, Converter<Message,Object>
+        ConfiguredResource<GenericJmsConsumerConfiguration>, ResubmissionService<Message>, Converter<Message,Object>, MultiThreadedCapable
 {
     /** class logger */
     private static Logger logger = Logger.getLogger(GenericJmsConsumer.class);

--- a/ikasaneip/component/endpoint/jms-spring/src/main/java/org/ikasan/component/endpoint/jms/spring/consumer/JmsContainerConsumer.java
+++ b/ikasaneip/component/endpoint/jms-spring/src/main/java/org/ikasan/component/endpoint/jms/spring/consumer/JmsContainerConsumer.java
@@ -46,6 +46,7 @@ import org.ikasan.component.endpoint.jms.consumer.JmsMessageConverter;
 import org.ikasan.component.endpoint.jms.consumer.MessageProvider;
 import org.ikasan.exclusion.service.IsExclusionServiceAware;
 import org.ikasan.spec.component.endpoint.Consumer;
+import org.ikasan.spec.component.endpoint.MultiThreadedCapable;
 import org.ikasan.spec.component.transformation.Converter;
 import org.ikasan.spec.component.transformation.TransformationException;
 import org.ikasan.spec.configuration.Configured;
@@ -73,7 +74,7 @@ public class JmsContainerConsumer
         implements MessageListener, ExceptionListener, ErrorHandler,
         Consumer<EventListener<?>,EventFactory>, Converter<Message,Object>,
         ManagedIdentifierService<ManagedEventIdentifierService>, ConfiguredResource<SpringMessageConsumerConfiguration>
-		, ResubmissionService<Message>, IsExclusionServiceAware
+		, ResubmissionService<Message>, IsExclusionServiceAware, MultiThreadedCapable
 {
     /** Logger instance */
     private Logger logger = Logger.getLogger(JmsContainerConsumer.class);

--- a/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumer.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumer.java
@@ -263,7 +263,7 @@ public class ScheduledConsumer<T>
             // We need to restart the business schedule PRIOR to cancelling the recovery
             // otherwise the change in state on cancelling recovery reports the
             // consumer as stopped as the business schedule isn't active.
-            // Starting it before the cancel should not cause any issues
+            // Starting it before the cancelAll should not cause any issues
             // as we only allow one quartz callback at a time and so will get
             // blocked until this recovery schedule has completed.
 
@@ -273,7 +273,7 @@ public class ScheduledConsumer<T>
                 this.start();
             }
 
-            // cancel the recovery schedule if still active
+            // cancelAll the recovery schedule if still active
             // could be the flow has already cancelled this, so check
             if(managedResourceRecoveryManager.isRecovering())
             {
@@ -322,7 +322,7 @@ public class ScheduledConsumer<T>
 
         if(isRecovering)
         {
-            // cancel the recovery schedule if still active
+            // cancelAll the recovery schedule if still active
             // could be the flow has already cancelled this, so check
             if(managedResourceRecoveryManager.isRecovering())
             {

--- a/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumer.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/main/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumer.java
@@ -231,6 +231,7 @@ public class ScheduledConsumer<T>
         }
         catch (Throwable thr)
         {
+            thr.printStackTrace();
             managedResourceRecoveryManager.recover(thr);
         }
     }

--- a/ikasaneip/component/endpoint/quartz-schedule/src/test/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumerTest.java
+++ b/ikasaneip/component/endpoint/quartz-schedule/src/test/java/org/ikasan/component/endpoint/quartz/consumer/ScheduledConsumerTest.java
@@ -75,31 +75,31 @@ public class ScheduledConsumerTest
     };
 
     /** Mock scheduler */
-    final Scheduler scheduler = mockery.mock(Scheduler.class, "mockScheduler");
+    private final Scheduler scheduler = mockery.mock(Scheduler.class, "mockScheduler");
 
     /** Mock job detail */
-    final JobDetail mockJobDetail = mockery.mock(JobDetail.class, "mockJobDetail");
+    private final JobDetail mockJobDetail = mockery.mock(JobDetail.class, "mockJobDetail");
 
     /** Mock trigger */
-    final Trigger trigger = mockery.mock(Trigger.class, "mockTrigger");
+    private final Trigger trigger = mockery.mock(Trigger.class, "mockTrigger");
 
     /** Mock flowEventFactory */
-    final EventFactory<FlowEvent> flowEventFactory = mockery.mock(EventFactory.class, "mockEventFactory");
+    private final EventFactory<FlowEvent> flowEventFactory = mockery.mock(EventFactory.class, "mockEventFactory");
 
     /** Mock consumerConfiguration */
-    final ScheduledConsumerConfiguration consumerConfiguration = 
+    private final ScheduledConsumerConfiguration consumerConfiguration =
         mockery.mock(ScheduledConsumerConfiguration.class, "mockScheduledConsumerConfiguration");
 
     /** Mock jobExecutionContext **/
-    final JobExecutionContext jobExecutionContext = mockery.mock(JobExecutionContext.class);
+    private final JobExecutionContext jobExecutionContext = mockery.mock(JobExecutionContext.class);
 
     /** Mock managedResourceRecoveryManager **/
-    final ManagedResourceRecoveryManager mockManagedResourceRecoveryManager = mockery.mock(ManagedResourceRecoveryManager.class);
+    private final ManagedResourceRecoveryManager mockManagedResourceRecoveryManager = mockery.mock(ManagedResourceRecoveryManager.class);
 
     /** consumer event listener */
-    final EventListener eventListener = mockery.mock(EventListener.class);
+    private final EventListener eventListener = mockery.mock(EventListener.class);
 
-    final ManagedEventIdentifierService  mockManagedEventIdentifierService = mockery.mock(ManagedEventIdentifierService.class);
+    private final ManagedEventIdentifierService  mockManagedEventIdentifierService = mockery.mock(ManagedEventIdentifierService.class);
 
 
     /**
@@ -378,7 +378,7 @@ public class ScheduledConsumerTest
                 exactly(2).of(mockManagedResourceRecoveryManager).isRecovering();
                 will(returnValue(true));
 
-                // cancel recovery
+                // cancelAll recovery
                 exactly(1).of(mockManagedResourceRecoveryManager).cancel();
 
                 // nope, consumer is not running

--- a/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/visitorPattern/VisitingInvokerFlow.java
+++ b/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/visitorPattern/VisitingInvokerFlow.java
@@ -72,7 +72,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Ikasan Development Team
  */
 @SuppressWarnings(value={"unchecked", "javadoc"})
-public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>, MonitorSubject, IsErrorReportingServiceAware, ConfiguredResource<FlowPersistentConfiguration>
+public class VisitingInvokerFlow<ID> implements Flow, EventListener<FlowEvent<?,?>>, MonitorSubject, IsErrorReportingServiceAware, ConfiguredResource<FlowPersistentConfiguration>
 {
 	/** logger instance */
     private static Logger logger = Logger.getLogger(VisitingInvokerFlow.class);
@@ -112,7 +112,7 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
     private Monitor monitor;
 
     /** stateful recovery manager implementation */
-    private RecoveryManager<FlowEvent<?,?>, FlowInvocationContext> recoveryManager;
+    private RecoveryManager<FlowEvent<?,?>, FlowInvocationContext, ID> recoveryManager;
     
     /** startup failure flag */
     private boolean flowInitialisationFailure = false;
@@ -166,7 +166,7 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
      * @param exclusionService
      */
     public VisitingInvokerFlow(String name, String moduleName, FlowConfiguration flowConfiguration,
-                               RecoveryManager<FlowEvent<?,?>, FlowInvocationContext> recoveryManager,
+                               RecoveryManager<FlowEvent<?,?>, FlowInvocationContext, ID> recoveryManager,
                                ExclusionService exclusionService, SerialiserFactory serialiserFactory)
     {
         this(name, moduleName, flowConfiguration, null, recoveryManager, exclusionService, serialiserFactory);
@@ -182,7 +182,7 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
      * @param exclusionService
      */
     public VisitingInvokerFlow(String name, String moduleName, FlowConfiguration flowConfiguration, ExclusionFlowConfiguration exclusionFlowConfiguration,
-                               RecoveryManager<FlowEvent<?,?>, FlowInvocationContext> recoveryManager,
+                               RecoveryManager<FlowEvent<?,?>, FlowInvocationContext, ID> recoveryManager,
                                ExclusionService exclusionService, SerialiserFactory serialiserFactory)
     {
         this.name = name;
@@ -449,7 +449,7 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
             // stop any active recovery
             if(this.recoveryManager.isRecovering())
             {
-                this.recoveryManager.cancel();
+                this.recoveryManager.cancelAll();
             }
 
             // stop consumer and remove the listener
@@ -701,7 +701,7 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
             this.consumerPaused = false;
 
             // stop any active recovery
-            this.recoveryManager.cancel();
+            this.recoveryManager.cancelAll();
 
             // stop consumer and remove the listener
             Consumer<?,?> consumer = this.flowConfiguration.getConsumerFlowElement().getFlowComponent();
@@ -732,7 +732,7 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
         flowInvocationContext.startFlowInvocation();
 
         // keep a handle on the original assigned eventLifeId as this could change within the flow
-        Object originalEventLifeIdentifier = event.getIdentifier();
+        ID originalEventLifeIdentifier = (ID)event.getIdentifier();
 
         try
         {
@@ -763,7 +763,7 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
                 updateDynamicConfiguredResources();
                 if(this.recoveryManager.isRecovering())
                 {
-                    this.recoveryManager.cancel();
+                    this.recoveryManager.cancel(originalEventLifeIdentifier); // we successfully executed for THIS identifier only
                 }
             }
             flowInvocationContext.endFlowInvocation();
@@ -797,14 +797,14 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
             updateDynamicConfiguredResources();
             if(this.recoveryManager.isRecovering())
             {
-                this.recoveryManager.cancel();
+                this.recoveryManager.cancel((ID)event.getEvent().getIdentifier());
             }
             flowInvocationContext.endFlowInvocation();
         }
         catch(Throwable throwable)
         {
             flowInvocationContext.endFlowInvocation();
-            this.recoveryManager.recover(flowInvocationContext, throwable, event.getEvent(), event.getEvent().getIdentifier());
+            this.recoveryManager.recover(flowInvocationContext, throwable, event.getEvent(), (ID)event.getEvent().getIdentifier());
         }
         finally
         {
@@ -1119,13 +1119,13 @@ public class VisitingInvokerFlow implements Flow, EventListener<FlowEvent<?,?>>,
 
             /*
              * (non-Javadoc)
-             * @see org.ikasan.spec.management.ManagedResourceRecoveryManager#cancel()
+             * @see org.ikasan.spec.management.ManagedResourceRecoveryManager#cancelAll()
              */
             public void cancel()
             {
                 try
                 {
-                    recoveryManager.cancel();
+                    recoveryManager.cancelAll();
                 }
                 finally
                 {

--- a/ikasaneip/flow/visitorPatternFlow/src/test/java/org/ikasan/flow/visitorPattern/VisitingInvokerFlowTest.java
+++ b/ikasaneip/flow/visitorPatternFlow/src/test/java/org/ikasan/flow/visitorPattern/VisitingInvokerFlowTest.java
@@ -40,12 +40,6 @@
  */
 package org.ikasan.flow.visitorPattern;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import javassist.bytecode.Descriptor.Iterator;
-
 import org.ikasan.flow.configuration.FlowElementPersistentConfiguration;
 import org.ikasan.flow.configuration.FlowPersistentConfiguration;
 import org.ikasan.flow.event.FlowEventFactory;
@@ -58,14 +52,7 @@ import org.ikasan.spec.error.reporting.IsErrorReportingServiceAware;
 import org.ikasan.spec.event.EventFactory;
 import org.ikasan.spec.event.EventListener;
 import org.ikasan.spec.exclusion.ExclusionService;
-import org.ikasan.spec.flow.Flow;
-import org.ikasan.spec.flow.FlowConfiguration;
-import org.ikasan.spec.flow.FlowElement;
-import org.ikasan.spec.flow.FlowElementInvoker;
-import org.ikasan.spec.flow.FlowEvent;
-import org.ikasan.spec.flow.FlowEventListener;
-import org.ikasan.spec.flow.FlowInvocationContext;
-import org.ikasan.spec.flow.FlowInvocationContextListener;
+import org.ikasan.spec.flow.*;
 import org.ikasan.spec.management.ManagedResource;
 import org.ikasan.spec.management.ManagedResourceRecoveryManager;
 import org.ikasan.spec.monitor.Monitor;
@@ -81,6 +68,10 @@ import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * This test class supports the <code>VisitingInvokerFlow</code> class.
@@ -1456,7 +1447,7 @@ public class VisitingInvokerFlowTest
         mockery.checking(new Expectations()
         {
             {
-                oneOf(recoveryManager).cancel();
+                oneOf(recoveryManager).cancelAll();
 
                 // get the consumer
                 oneOf(flowConfiguration).getConsumerFlowElement();
@@ -1591,7 +1582,7 @@ public class VisitingInvokerFlowTest
         mockery.checking(new Expectations()
         {
             {
-                oneOf(recoveryManager).cancel();
+                oneOf(recoveryManager).cancelAll();
 
                 // get the consumer
                 oneOf(flowConfiguration).getConsumerFlowElement();
@@ -1728,7 +1719,7 @@ public class VisitingInvokerFlowTest
         mockery.checking(new Expectations()
         {
             {
-                oneOf(recoveryManager).cancel();
+                oneOf(recoveryManager).cancelAll();
 
                 // get the consumer
                 oneOf(flowConfiguration).getConsumerFlowElement();
@@ -1864,7 +1855,7 @@ public class VisitingInvokerFlowTest
             {
                 // always check to see if recovery is in progress
                 // in this test case it isn't
-                oneOf(recoveryManager).cancel();
+                oneOf(recoveryManager).cancelAll();
 
                 // get the consumer
                 oneOf(flowConfiguration).getConsumerFlowElement();
@@ -2043,7 +2034,7 @@ public class VisitingInvokerFlowTest
 
                 exactly(2).of(flowConfiguration).update(dynamicConfiguredResource);
 
-                // in this test we do not need to cancel recovery
+                // in this test we do not need to cancelAll recovery
                 oneOf(recoveryManager).isRecovering();
                 will(returnValue(false));
             }
@@ -2131,7 +2122,7 @@ public class VisitingInvokerFlowTest
 
                 oneOf(flowInvocationContextListener).endFlow(flowInvocationContext);
 
-                // in this test we do not need to cancel recovery
+                // in this test we do not need to cancelAll recovery
                 oneOf(recoveryManager).isRecovering();
                 will(returnValue(false));
             }
@@ -2216,7 +2207,7 @@ public class VisitingInvokerFlowTest
 
                 exactly(2).of(flowConfiguration).update(dynamicConfiguredResource);
 
-                // in this test we do not need to cancel recovery
+                // in this test we do not need to cancelAll recovery
                 oneOf(recoveryManager).isRecovering();
                 will(returnValue(false));
             }
@@ -2306,7 +2297,7 @@ public class VisitingInvokerFlowTest
 
                 oneOf(flowInvocationContextListener).endFlow(flowInvocationContext);
 
-                // in this test we do not need to cancel recovery
+                // in this test we do not need to cancelAll recovery
                 oneOf(recoveryManager).isRecovering();
                 will(returnValue(false));
             }
@@ -3216,7 +3207,7 @@ public class VisitingInvokerFlowTest
     {
 
         public ExtendedVisitingInvokerFlow(String name, String moduleName, FlowConfiguration flowConfiguration,
-                                           RecoveryManager<FlowEvent<?,?>, FlowInvocationContext> recoveryManager, ExclusionService exclusionService)
+                                           RecoveryManager<FlowEvent<?,?>, FlowInvocationContext, ?> recoveryManager, ExclusionService exclusionService)
         {
             super(name, moduleName, flowConfiguration, exclusionFlowConfiguration, recoveryManager, exclusionService, serialiserFactory);
         }

--- a/ikasaneip/recovery-manager/src/main/java/org/ikasan/recovery/ScheduledRecoveryManager.java
+++ b/ikasaneip/recovery-manager/src/main/java/org/ikasan/recovery/ScheduledRecoveryManager.java
@@ -41,11 +41,11 @@
 package org.ikasan.recovery;
 
 import org.apache.log4j.Logger;
-import org.apache.log4j.or.ThreadGroupRenderer;
 import org.ikasan.exceptionResolver.ExceptionResolver;
 import org.ikasan.exceptionResolver.action.*;
 import org.ikasan.scheduler.ScheduledJobFactory;
 import org.ikasan.spec.component.endpoint.Consumer;
+import org.ikasan.spec.component.endpoint.MultiThreadedCapable;
 import org.ikasan.spec.error.reporting.ErrorReportingService;
 import org.ikasan.spec.event.ForceTransactionRollbackException;
 import org.ikasan.spec.exclusion.ExclusionService;
@@ -53,13 +53,14 @@ import org.ikasan.spec.flow.FinalAction;
 import org.ikasan.spec.flow.FlowElement;
 import org.ikasan.spec.flow.FlowInvocationContext;
 import org.ikasan.spec.management.ManagedResource;
-import org.ikasan.exceptionResolver.action.ExceptionAction;
 import org.ikasan.spec.recovery.RecoveryManager;
 import org.quartz.*;
 
 import java.text.ParseException;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.quartz.CronScheduleBuilder.cronSchedule;
 import static org.quartz.TriggerBuilder.newTrigger;
@@ -71,24 +72,22 @@ import static org.quartz.TriggerKey.triggerKey;
  * @author Ikasan Development Team
  */
 @DisallowConcurrentExecution
-public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolver, FlowInvocationContext>, Job
+public class ScheduledRecoveryManager<ID> implements RecoveryManager<ExceptionResolver, FlowInvocationContext, ID>, Job
 {
     /** logger */
     private static Logger logger = Logger.getLogger(ScheduledRecoveryManager.class);
 
     /** recovery job name */
-    protected static final String RECOVERY_JOB_NAME = "recoveryJob_";
+    private static final String RECOVERY_JOB_NAME = "recoveryJob_";
 
     /** consumer recovery job name */
-    protected static final String CONSUMER_RECOVERY_JOB_NAME = "consumerRecoveryJob_";
+    private static final String CONSUMER_RECOVERY_JOB_NAME = "consumerRecoveryJob_";
 
     /** recovery job trigger name */
-    protected static final String RECOVERY_JOB_TRIGGER_NAME = "recoveryJobTrigger_";
+    private static final String RECOVERY_JOB_TRIGGER_NAME = "recoveryJobTrigger_";
 
     /** recovery job trigger name */
-    protected static final String IMMEDIATE_RECOVERY_JOB_TRIGGER_NAME = "immediateRecoveryJobTrigger_";
-
-    protected static final String JOB_IDENTIFIER = "jobIdentifier";
+    private static final String IMMEDIATE_RECOVERY_JOB_TRIGGER_NAME = "immediateRecoveryJobTrigger_";
 
     /** consumer to stop and start for recovery */
     private Consumer<?,?> consumer;
@@ -129,15 +128,21 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
     /** Error Reporting Service */
     private ErrorReportingService errorReportingService;
 
-    private long jobIdentifier = 0L;
+    private JobKey recoveryJobKey;
+
+    private JobKey consumerRecoveryJobKey;
+
+    private Set<Object> recoveringIdentifiers = new HashSet<>();
+
+    private boolean isConsumerMultiThreaded = false;
 
     /**
      * Constructor
-     * @param scheduler
-     * @param scheduledJobFactory
-     * @param flowName
-     * @param moduleName
-     * @param consumer
+     * @param scheduler the Scheduler
+     * @param scheduledJobFactory a ScheduledJobFactory
+     * @param flowName the name of the flow to which this manager is attached
+     * @param moduleName the module name
+     * @param consumer the consumer for the given flow
      */
     public ScheduledRecoveryManager(Scheduler scheduler, ScheduledJobFactory scheduledJobFactory, String flowName, String moduleName,
                                     Consumer<?,?> consumer, ExclusionService exclusionService, ErrorReportingService errorReportingService)
@@ -183,11 +188,15 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
         {
             throw new IllegalArgumentException("errorReportingService cannot be null");
         }
+        if (consumer instanceof MultiThreadedCapable)
+        {
+            isConsumerMultiThreaded = true;
+        }
     }
 
     /**
      * Set a specific exception resolver
-     * @param exceptionResolver
+     * @param exceptionResolver an ExceptionResolver
      */
     public void setResolver(ExceptionResolver exceptionResolver)
     {
@@ -223,17 +232,18 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
     /**
      * Common resolution of the action for the componentName and throwable instance
      *
-     * @param action
-     * @param componentName
-     * @param throwable 
+     * @param action the given ExceptionAction
+     * @param componentName the name of the component that threw the original exception
+     * @param throwable  the exception that was thrown
+     * @param id the identifier of the FlowEvent
      */
-    protected void recover(ExceptionAction action, String componentName, Throwable throwable)
+    protected void recover(ExceptionAction action, String componentName, Throwable throwable, ID id)
     {
         if(action instanceof StopAction)
         {
             if(isRecovering())
             {
-                this.cancelRecovery();
+                cancelAll();
             }
             
             this.consumer.stop();
@@ -252,7 +262,11 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
 
             this.consumer.stop();
             stopManagedResources();
-                
+
+            if (isConsumerMultiThreaded)
+            {
+                recoveringIdentifiers.add(id);
+            }
             try
             {
                 if(!isRecovering())
@@ -268,7 +282,7 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
                     }
                     else
                     {
-                        cancelRecovery();
+                        cancelAll();
                         startRecovery(retryAction);
                     }
                 }
@@ -307,7 +321,7 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
                     }
                     else
                     {
-                        cancelRecovery();
+                        cancelAll();
                         startRecovery(scheduledRetryAction);
                     }
                 }
@@ -329,9 +343,10 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
     }
 
     /**
-     * Execute recovery based on the specified component name and exception.
-     * @param componentName
-     * @param throwable
+     * Execute recovery based on the specified component name and exception. This is usually called when a flow fails to start
+     * and no identifier is present
+     * @param componentName the name of the component that threw the exception (usually the consumer)
+     * @param throwable the exception
      */
     @Override
     public void recover(String componentName, Throwable throwable)
@@ -343,7 +358,7 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
         }
 
         this.errorReportingService.notify(componentName, throwable, action.toString());
-        this.recover(action, componentName, throwable);
+        this.recover(action, componentName, throwable, null);
     }
 
     /**
@@ -353,11 +368,10 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
      * @param event
      * @param identifier
      * @param <T>
-     * @param <TID>
      */
     @Override
     @SuppressWarnings("unchecked")
-    public <T,TID> void recover(FlowInvocationContext flowInvocationContext, Throwable throwable, T event, TID identifier)
+    public <T> void recover(FlowInvocationContext flowInvocationContext, Throwable throwable, T event, ID identifier)
     {
         String lastComponentName = flowInvocationContext.getLastComponentName();
         ExceptionAction action = resolveAction(lastComponentName, throwable);
@@ -374,7 +388,7 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
             throw new ForceTransactionRollbackException(action.toString(), throwable);
         }
 
-        this.recover(action, lastComponentName, throwable);
+        this.recover(action, lastComponentName, throwable, identifier);
     }
 
     protected FinalAction getFinalAction(ExceptionAction exceptionAction)
@@ -410,7 +424,7 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
         throws SchedulerException
     {
         JobDetail recoveryJobDetail = scheduledJobFactory.createJobDetail(this, ScheduledRecoveryManager.class, RECOVERY_JOB_NAME + this.flowName + Thread.currentThread().getId(), this.moduleName);
-        recoveryJobDetail.getJobDataMap().put(JOB_IDENTIFIER, Thread.currentThread().getId());
+        recoveryJobKey = recoveryJobDetail.getKey(); // store the jobkey for this recovery execution so it can be cancelled in-flight
         Trigger recoveryJobTrigger = newRecoveryTrigger(retryAction.getDelay());
         Date scheduled = this.scheduler.scheduleJob(recoveryJobDetail, recoveryJobTrigger);
 
@@ -426,11 +440,10 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
      * @param scheduledRetryAction
      * @throws SchedulerException
      */
-    private void startRecovery(ScheduledRetryAction scheduledRetryAction)
-            throws SchedulerException
+    private void startRecovery(ScheduledRetryAction scheduledRetryAction) throws SchedulerException
     {
         JobDetail recoveryJobDetail = scheduledJobFactory.createJobDetail(this, ScheduledRecoveryManager.class, RECOVERY_JOB_NAME + this.flowName + Thread.currentThread().getId(), this.moduleName);
-        recoveryJobDetail.getJobDataMap().put(JOB_IDENTIFIER, Thread.currentThread().getId());
+        recoveryJobKey = recoveryJobDetail.getKey(); // store the jobkey for this recovery execution so it can be cancelled in-flight
         Trigger recoveryJobTrigger = newRecoveryTrigger(scheduledRetryAction.getCronExpression());
         Date scheduled = this.scheduler.scheduleJob(recoveryJobDetail, recoveryJobTrigger);
 
@@ -451,7 +464,7 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
 
         if(retryAction.getMaxRetries() != RetryAction.RETRY_INFINITE && recoveryAttempts > retryAction.getMaxRetries())
         {
-            this.cancelRecovery();
+            cancelAll();
             this.isUnrecoverable = true;
 
             // TODO - define a better exception!?!
@@ -459,14 +472,14 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
         }
 
         JobDetail recoveryJobDetail = scheduledJobFactory.createJobDetail(this, ScheduledRecoveryManager.class, RECOVERY_JOB_NAME + this.flowName + Thread.currentThread().getId(), this.moduleName);
-        recoveryJobDetail.getJobDataMap().put(JOB_IDENTIFIER, Thread.currentThread().getId());
+        recoveryJobKey = recoveryJobDetail.getKey(); // store the jobkey for this recovery execution so it can be cancelled in-flight
         Trigger recoveryJobTrigger = newRecoveryTrigger(retryAction.getDelay());
         
         // Only schedule a new recovery if we don't have one in-progress.
         // This can be the case on very high volume feeds where 
         // multiple recoveries are created by in-flight messages 
         // between stop/start of the flow
-        if(this.scheduler.checkExists(recoveryJobDetail.getKey()))
+        if(this.scheduler.checkExists(recoveryJobKey))
         {
             logger.info("Recovery in progress flow [" 
                 + flowName + "] module [" + moduleName 
@@ -493,7 +506,7 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
 
         if(scheduledRetryAction.getMaxRetries() != RetryAction.RETRY_INFINITE && recoveryAttempts > scheduledRetryAction.getMaxRetries())
         {
-            this.cancelRecovery();
+            this.cancelRecovery(null);
             this.isUnrecoverable = true;
 
             // TODO - define a better exception!?!
@@ -505,18 +518,26 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
     }
 
     /**
-     * Cancel an in progress recovery.
+     * Cancel an in progress recovery based on an optional identifier. If the id is null it cancels all jobs THIS recovery manager knows about
      */
-    private void cancelRecovery()
+    private void cancelRecovery(ID id)
     {
         recoveryAttempts = 0;
-
+        boolean wasIdInRecovery = recoveringIdentifiers.remove(id);
         try
-        {
-            cancelScheduledJob();
-            this.previousComponentName = null;
-            this.previousExceptionAction = null;
-            logger.info("Recovery cancelled for flow [" + flowName + "] module [" + moduleName + "]");
+        {   //  no id      || consumer is single threaded || identifiers is empty and this id was the last to exit recovery
+            if (id == null || !isConsumerMultiThreaded || (wasIdInRecovery && recoveringIdentifiers.isEmpty()))
+            {
+                cancelScheduledJob();
+                this.previousComponentName = null;
+                this.previousExceptionAction = null;
+                logger.info("Recovery all cancelled for flow [" + flowName + "] module [" + moduleName + "]");
+                recoveringIdentifiers.clear();
+            }
+            else
+            {
+                logger.warn("Not cancelling recovery for identifier " + id + " - currently recovering identifiers: " + recoveringIdentifiers.toString());
+            }
         }
         catch(SchedulerException e)
         {
@@ -528,11 +549,17 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
     /**
      * Cancel an in progress recovery.
      */
-    public void cancel()
+    public void cancelAll()
     {
-        this.cancelRecovery();
+        this.cancelRecovery(null);
     }
-    
+
+    @Override
+    public void cancel(ID identifier)
+    {
+        this.cancelRecovery(identifier);
+    }
+
     public void initialise()
     {
         this.isUnrecoverable = false;
@@ -613,39 +640,37 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
 
     /**
      * Cancel the recovery job with the scheduler.
-     * @throws SchedulerException
+     * @throws SchedulerException on exception with the Scheduler
      */
     private void cancelScheduledJob() throws SchedulerException
     {
-        JobKey jobKey = new JobKey(RECOVERY_JOB_NAME + this.flowName + this.jobIdentifier, this.moduleName);
-        boolean deleteRecoveryJob = this.scheduler.deleteJob(jobKey);
-        logger.info("Tried to remove recovery job " + jobKey + " with result :" + deleteRecoveryJob);
+        boolean deletedRecoveryJob = this.scheduler.deleteJob(recoveryJobKey);
+        logger.info("Tried to remove recovery job " + recoveryJobKey + " with result :" + deletedRecoveryJob);
 
-        JobKey consumerJobKey = new JobKey(CONSUMER_RECOVERY_JOB_NAME + this.flowName + this.jobIdentifier, this.moduleName);
-        if(this.scheduler.checkExists(consumerJobKey))
+        if(consumerRecoveryJobKey != null && this.scheduler.checkExists(consumerRecoveryJobKey))
         {
-
-            boolean deleteConsumerRecoveryJob = this.scheduler.deleteJob(consumerJobKey);
-            logger.info("Tried to remove consumer recovery job " + consumerJobKey + " with result :" + deleteConsumerRecoveryJob);
+            boolean deletedConsumerRecoveryJob = this.scheduler.deleteJob(consumerRecoveryJobKey);
+            logger.info("Tried to remove consumer recovery job " + consumerRecoveryJobKey + " with result :" + deletedConsumerRecoveryJob);
         }
     }
 
     /**
      * Callback from the scheduler.
-     * @param context
+     * @param context the jbo execution context
      */
+    @SuppressWarnings("unchecked")
     public void execute(JobExecutionContext context) throws JobExecutionException
     {
         try
         {
-            this.jobIdentifier = (Long)context.getMergedJobDataMap().get(JOB_IDENTIFIER);
             startManagedResources();
 
             if(this.consumer instanceof Job)
             {
                 Class consumerClass = this.consumer.getClass();
-                JobDetail recoveryJobDetail = scheduledJobFactory.createJobDetail((Job)this.consumer, consumerClass, CONSUMER_RECOVERY_JOB_NAME + this.flowName+this.jobIdentifier, this.moduleName);
-                recoveryJobDetail.getJobDataMap().put(JOB_IDENTIFIER, this.jobIdentifier);
+                JobDetail recoveryJobDetail = scheduledJobFactory.createJobDetail((Job)this.consumer, consumerClass, CONSUMER_RECOVERY_JOB_NAME + this.flowName, this.moduleName);
+                consumerRecoveryJobKey = recoveryJobDetail.getKey(); // set the consumer's jobkey so it can be canceled as necessary
+
                 this.scheduler.scheduleJob(recoveryJobDetail, newImmediateRecoveryTrigger());
             }
             else

--- a/ikasaneip/recovery-manager/src/main/java/org/ikasan/recovery/ScheduledRecoveryManager.java
+++ b/ikasaneip/recovery-manager/src/main/java/org/ikasan/recovery/ScheduledRecoveryManager.java
@@ -129,7 +129,7 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
     /** Error Reporting Service */
     private ErrorReportingService errorReportingService;
 
-    private Long jobIdentifier = 0L;
+    private long jobIdentifier = 0L;
 
     /**
      * Constructor
@@ -618,12 +618,15 @@ public class ScheduledRecoveryManager implements RecoveryManager<ExceptionResolv
     private void cancelScheduledJob() throws SchedulerException
     {
         JobKey jobKey = new JobKey(RECOVERY_JOB_NAME + this.flowName + this.jobIdentifier, this.moduleName);
-        this.scheduler.deleteJob(jobKey);
+        boolean deleteRecoveryJob = this.scheduler.deleteJob(jobKey);
+        logger.info("Tried to remove recovery job " + jobKey + " with result :" + deleteRecoveryJob);
 
         JobKey consumerJobKey = new JobKey(CONSUMER_RECOVERY_JOB_NAME + this.flowName + this.jobIdentifier, this.moduleName);
         if(this.scheduler.checkExists(consumerJobKey))
         {
-            this.scheduler.deleteJob(consumerJobKey);
+
+            boolean deleteConsumerRecoveryJob = this.scheduler.deleteJob(consumerJobKey);
+            logger.info("Tried to remove consumer recovery job " + consumerJobKey + " with result :" + deleteConsumerRecoveryJob);
         }
     }
 

--- a/ikasaneip/recovery-manager/src/test/java/org/ikasan/recovery/ScheduledRecoveryManagerTest.java
+++ b/ikasaneip/recovery-manager/src/test/java/org/ikasan/recovery/ScheduledRecoveryManagerTest.java
@@ -51,7 +51,6 @@ import org.ikasan.spec.flow.FlowElement;
 import org.ikasan.spec.flow.FlowEvent;
 import org.ikasan.spec.flow.FlowInvocationContext;
 import org.ikasan.spec.management.ManagedResource;
-import org.ikasan.exceptionResolver.action.ExceptionAction;
 import org.ikasan.spec.recovery.RecoveryManager;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -63,7 +62,6 @@ import org.quartz.*;
 import org.quartz.impl.StdSchedulerFactory;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -71,6 +69,7 @@ import java.util.List;
  * 
  * @author Ikasan Development Team
  */
+@SuppressWarnings("unchecked")
 public class ScheduledRecoveryManagerTest
 {
     /**
@@ -85,52 +84,52 @@ public class ScheduledRecoveryManagerTest
     };
     
     /** Mock consumer flowElement */
-    final Consumer consumer = mockery.mock(Consumer.class, "mockConsumer");
+    private final Consumer consumer = mockery.mock(Consumer.class, "mockConsumer");
 
     /** Mock exception resolver */
-    final ExceptionResolver exceptionResolver = mockery.mock(ExceptionResolver.class, "mockExceptionResolver");
+    private final ExceptionResolver exceptionResolver = mockery.mock(ExceptionResolver.class, "mockExceptionResolver");
 
     /** Mock scheduler */
-    final Scheduler scheduler = mockery.mock(Scheduler.class, "mockScheduler");
+    private final Scheduler scheduler = mockery.mock(Scheduler.class, "mockScheduler");
 
     /** Mock scheduledJobFactory */
-    final ScheduledJobFactory scheduledJobFactory = mockery.mock(ScheduledJobFactory.class, "mockScheduledJobFactory");
+    private final ScheduledJobFactory scheduledJobFactory = mockery.mock(ScheduledJobFactory.class, "mockScheduledJobFactory");
 
     /** Mock recovery job detail */
-    final JobDetail jobDetail = mockery.mock(JobDetail.class, "mockJobDetail");
+    private final JobDetail jobDetail = mockery.mock(JobDetail.class, "mockJobDetail");
 
     /** Mock recovery job trigger */
-    final Trigger trigger = mockery.mock(Trigger.class, "mockTrigger");
+    private final Trigger trigger = mockery.mock(Trigger.class, "mockTrigger");
 
     /** Mock stopAction */
-    final StopAction stopAction = mockery.mock(StopAction.class, "Stop");
+    private final StopAction stopAction = mockery.mock(StopAction.class, "Stop");
     
     /** Mock retryAction */
-    final RetryAction retryAction = mockery.mock(RetryAction.class, "Retry");
+    private final RetryAction retryAction = mockery.mock(RetryAction.class, "Retry");
     
     /** Mock excludeEventAction */
-    final ExcludeEventAction excludeEventAction = mockery.mock(ExcludeEventAction.class, "ExcludeEvent");
+    private final ExcludeEventAction excludeEventAction = mockery.mock(ExcludeEventAction.class, "ExcludeEvent");
     
     /** Mock ignoreAction */
-    final IgnoreAction ignoreAction = mockery.mock(IgnoreAction.class, "Ignore");
+    private final IgnoreAction ignoreAction = mockery.mock(IgnoreAction.class, "Ignore");
     
     /** Mock flowElement */
-    final FlowElement flowElement = mockery.mock(FlowElement.class, "FlowElement");
+    private final FlowElement flowElement = mockery.mock(FlowElement.class, "FlowElement");
     
     /** Mock managedResource */
-    final ManagedResource managedResource = mockery.mock(ManagedResource.class, "ManagedResource");
+    private final ManagedResource managedResource = mockery.mock(ManagedResource.class, "ManagedResource");
 
     /** Mock exclusion service */
-    final ExclusionService exclusionService = mockery.mock(ExclusionService.class, "mockExclusionService");
+    private final ExclusionService exclusionService = mockery.mock(ExclusionService.class, "mockExclusionService");
 
     /** Mock error reporting service */
-    final ErrorReportingService errorReportingService = mockery.mock(ErrorReportingService.class, "mockErrorReportingService");
+    private final ErrorReportingService errorReportingService = mockery.mock(ErrorReportingService.class, "mockErrorReportingService");
 
     /** Mock flowEvent */
-    final FlowEvent flowEvent = mockery.mock(FlowEvent.class, "mockFlowEvent");
+    private final FlowEvent flowEvent = mockery.mock(FlowEvent.class, "mockFlowEvent");
 
     /** Mock flowInvocationContext*/
-    final FlowInvocationContext flowInvocationContext = mockery.mock(FlowInvocationContext.class, "flowInvocationContext");
+    private final FlowInvocationContext flowInvocationContext = mockery.mock(FlowInvocationContext.class, "flowInvocationContext");
 
     /**
      * Test failed constructor due to null scheduler.
@@ -205,7 +204,7 @@ public class ScheduledRecoveryManagerTest
     }
 
     /**
-     * Test we can call cancel on the recovery manager even if no recovery jobs are in progress
+     * Test we can call cancelAll on the recovery manager even if no recovery jobs are in progress
      * @throws SchedulerException if the scheduler setup fails
      */
     @Test
@@ -215,13 +214,13 @@ public class ScheduledRecoveryManagerTest
         Scheduler scheduler = StdSchedulerFactory.getDefaultScheduler();
         scheduler.start();
         ScheduledRecoveryManager scheduledRecoveryManager = new StubbedScheduledRecoveryManager(scheduler, "flow", "module", consumer);
-        scheduledRecoveryManager.cancel();
-        Assert.assertTrue("cancel called with no jobs", true);
+        scheduledRecoveryManager.cancelAll();
+        Assert.assertTrue("cancelAll called with no jobs", true);
     }
 
     /**
      * Test successful stop action on recovery.
-     * @throws SchedulerException 
+     * @throws SchedulerException if the scheduler fails
      */
     @Test
     public void test_successful_recover_to_stopAction_with_no_previousAction_noManagedResources() throws SchedulerException
@@ -265,7 +264,7 @@ public class ScheduledRecoveryManagerTest
 
     /**
      * Test successful exclude action on recovery.
-     * @throws SchedulerException
+     * @throws SchedulerException if the scheduler fails
      */
     @Test
     public void test_successful_recover_to_excludeAction() throws SchedulerException
@@ -313,7 +312,7 @@ public class ScheduledRecoveryManagerTest
 
     /**
      * Test successful stop action on recovery.
-     * @throws SchedulerException 
+     * @throws SchedulerException if the scheduler fails
      */
     @Test
     public void test_successful_recover_to_stopAction_with_no_previousAction_withManagedResources() throws SchedulerException
@@ -365,7 +364,7 @@ public class ScheduledRecoveryManagerTest
 
     /**
      * Test successful ignore action on recovery.
-     * @throws SchedulerException 
+     * @throws SchedulerException if the scheduler fails
      */
     @Test
     public void test_successful_recover_to_ignoreAction_with_no_previousAction_noManagedResources() throws SchedulerException
@@ -394,7 +393,7 @@ public class ScheduledRecoveryManagerTest
 
     /**
      * Test successful ignore action on recovery.
-     * @throws SchedulerException 
+     * @throws SchedulerException if the scheduler fails
      */
     @Test
     public void test_successful_recover_to_ignoreAction_with_no_previousAction_withManagedResources() throws SchedulerException
@@ -428,13 +427,14 @@ public class ScheduledRecoveryManagerTest
 
     /**
      * Test successful retry action on recovery.
-     * @throws SchedulerException 
+     * @throws SchedulerException if the scheduler fails
      */
     @Test
     public void test_successful_recover_to_retryAction_with_no_previousAction_noManagedResources() throws SchedulerException
     {
         final Exception exception = new Exception();
-        
+        final JobKey jobKey = new JobKey("recoveryJob_flowName" + 0, "moduleName");
+
         final RecoveryManager recoveryManager = new StubbedScheduledRecoveryManager(scheduler, "flowName", "moduleName", consumer);
 
         // expectations
@@ -452,6 +452,9 @@ public class ScheduledRecoveryManagerTest
                 // firstly stop the consumer
                 exactly(1).of(consumer).stop();
 
+                exactly(1).of(jobDetail).getKey();
+                will(returnValue(jobKey));
+
                 // for this test we are not already in a recovery
                 exactly(1).of(scheduler).isStarted();
                 will(returnValue(false));
@@ -464,9 +467,6 @@ public class ScheduledRecoveryManagerTest
                 exactly(1).of(scheduledJobFactory).createJobDetail(with(any(Job.class)), with(any(Class.class)), with(any(String.class)), with(any(String.class)));
                 will(returnValue(jobDetail));
 
-                exactly(1).of(jobDetail).getJobDataMap();
-                will(returnValue(new JobDataMap()));
-                
                 exactly(2).of(retryAction).getMaxRetries();
                 will(returnValue(2));
                 exactly(1).of(retryAction).getDelay();
@@ -503,7 +503,7 @@ public class ScheduledRecoveryManagerTest
 
     /**
      * Test successful retry action on recovery.
-     * @throws SchedulerException 
+     * @throws SchedulerException if the scheduler fails
      */
     @Test
     public void test_successful_recover_to_retryAction_with_no_previousAction_withManagedResources() throws SchedulerException
@@ -511,6 +511,7 @@ public class ScheduledRecoveryManagerTest
         final Exception exception = new Exception();
         
         final RecoveryManager recoveryManager = new StubbedScheduledRecoveryManager(scheduler, "flowName", "moduleName", consumer);
+        final JobKey jobKey = new JobKey("recoveryJob_flowName" + 0, "moduleName");
         final List managedResources = new ArrayList();
         managedResources.add(flowElement);
 
@@ -537,7 +538,9 @@ public class ScheduledRecoveryManagerTest
                 // for this test we are not already in a recovery
                 exactly(1).of(scheduler).isStarted();
                 will(returnValue(false));
-                
+
+                exactly(1).of(jobDetail).getKey();
+                will(returnValue(jobKey));
 //                // so start the scheduler
 //                exactly(1).of(scheduler).start();
 
@@ -546,9 +549,6 @@ public class ScheduledRecoveryManagerTest
                 exactly(1).of(scheduledJobFactory).createJobDetail(with(any(Job.class)), with(any(Class.class)), with(any(String.class)), with(any(String.class)));
                 will(returnValue(jobDetail));
 
-                exactly(1).of(jobDetail).getJobDataMap();
-                will(returnValue(new JobDataMap()));
-                
                 exactly(2).of(retryAction).getMaxRetries();
                 will(returnValue(2));
                 exactly(1).of(retryAction).getDelay();
@@ -587,7 +587,7 @@ public class ScheduledRecoveryManagerTest
     /**
      * Test successful three consecutive retry actions with the last one
      * exceeding the maximum attempts limit.
-     * @throws SchedulerException 
+     * @throws SchedulerException if the scheduler fails
      */
     @Test
     public void test_successful_recover_to_three_retryActions_until_exceeds_max_attempts_noManagedResources() throws SchedulerException
@@ -620,9 +620,6 @@ public class ScheduledRecoveryManagerTest
                 // for this test we are already in a recovery
                 exactly(1).of(scheduler).isStarted();
                 will(returnValue(true));
-
-                exactly(1).of(jobDetail).getJobDataMap();
-                will(returnValue(new JobDataMap()));
                 
                 exactly(2).of(scheduledJobFactory).createJobDetail(with(any(Job.class)), with(any(Class.class)), with(any(String.class)), with(any(String.class)));
                 will(returnValue(jobDetail));
@@ -659,8 +656,7 @@ public class ScheduledRecoveryManagerTest
                 exactly(4).of(retryAction).getMaxRetries();
                 will(returnValue(maxRetries));
 
-                exactly(1).of(jobDetail).getJobDataMap();
-                will(returnValue(new JobDataMap()));
+
 
                 //
                 // third time retry action is invoked
@@ -682,20 +678,17 @@ public class ScheduledRecoveryManagerTest
                 will(returnValue(true));
                 
                 // is recovery job already scheduled
-                exactly(1).of(jobDetail).getKey();
+                exactly(2).of(jobDetail).getKey();
                 will(returnValue(jobKey));
                 exactly(1).of(scheduler).checkExists(jobKey);
-                will(returnValue(Boolean.FALSE));
+                will(returnValue(false));
 
                 // check we have not exceeded retry limits
                 exactly(1).of(retryAction).getMaxRetries();
                 will(returnValue(maxRetries));
                 
-                // cancel the recovery
+                // cancelAll the recovery
                 exactly(1).of(scheduler).deleteJob(jobKey);
-                exactly(1).of(scheduler).checkExists(consumerJobKey);
-                will(returnValue(Boolean.TRUE));
-                exactly(1).of(scheduler).deleteJob(consumerJobKey);
             }
         });
 
@@ -746,7 +739,7 @@ public class ScheduledRecoveryManagerTest
     /**
      * Test successful three consecutive retry actions with the last one
      * exceeding the maximum attempts limit.
-     * @throws SchedulerException 
+     * @throws SchedulerException if the scheduler fails
      */
     @Test
     public void test_successful_recover_to_three_retryActions_until_exceeds_max_attempts_withManagedResources() throws SchedulerException
@@ -755,7 +748,6 @@ public class ScheduledRecoveryManagerTest
         final long delay = 2000;
         final int maxRetries = 2;
         final JobKey jobKey = new JobKey("recoveryJob_flowName" + 0, "moduleName");
-        final JobKey consumerJobKey = new JobKey("consumerRecoveryJob_flowName" + 0, "moduleName");
         final List managedResources = new ArrayList();
         managedResources.add(flowElement);
 
@@ -787,9 +779,6 @@ public class ScheduledRecoveryManagerTest
                 exactly(1).of(scheduler).isStarted();
                 will(returnValue(true));
 
-                exactly(1).of(jobDetail).getJobDataMap();
-                will(returnValue(new JobDataMap()));
-                
                 exactly(2).of(scheduledJobFactory).createJobDetail(with(any(Job.class)), with(any(Class.class)), with(any(String.class)), with(any(String.class)));
                 will(returnValue(jobDetail));
                 
@@ -830,9 +819,6 @@ public class ScheduledRecoveryManagerTest
                 exactly(4).of(retryAction).getMaxRetries();
                 will(returnValue(maxRetries));
 
-                exactly(1).of(jobDetail).getJobDataMap();
-                will(returnValue(new JobDataMap()));
-
                 //
                 // third time retry action is invoked
                 // 
@@ -858,20 +844,17 @@ public class ScheduledRecoveryManagerTest
                 will(returnValue(true));
                 
                 // is recovery job already scheduled
-                exactly(1).of(jobDetail).getKey();
+                exactly(2).of(jobDetail).getKey();
                 will(returnValue(jobKey));
                 exactly(1).of(scheduler).checkExists(jobKey);
-                will(returnValue(Boolean.FALSE));
+                will(returnValue(false));
 
                 // check we have not exceeded retry limits
                 exactly(1).of(retryAction).getMaxRetries();
                 will(returnValue(maxRetries));
                 
-                // cancel the recovery
+                // cancelAll the recovery
                 exactly(1).of(scheduler).deleteJob(jobKey);
-                exactly(1).of(scheduler).checkExists(consumerJobKey);
-                will(returnValue(Boolean.TRUE));
-                exactly(1).of(scheduler).deleteJob(consumerJobKey);
             }
         });
 
@@ -959,7 +942,7 @@ public class ScheduledRecoveryManagerTest
     private class StubbedScheduledRecoveryManager extends ScheduledRecoveryManager
     {
 
-        public StubbedScheduledRecoveryManager(Scheduler scheduler, String flowName, String moduleName, Consumer consumer)
+        StubbedScheduledRecoveryManager(Scheduler scheduler, String flowName, String moduleName, Consumer consumer)
         {
             super(scheduler, scheduledJobFactory, flowName, moduleName, consumer, exclusionService, errorReportingService);
         }
@@ -973,7 +956,7 @@ public class ScheduledRecoveryManagerTest
         /**
          * Added to allow testing on retry attempts counter
          */
-        protected int getRetryAttempts()
+        int getRetryAttempts()
         {
             return this.recoveryAttempts;
         }

--- a/ikasaneip/sample/scheduleDrivenSrc/module/src/main/java/org/ikasan/sample/scheduleDrivenSrc/component/converter/ScheduleEventFailingConverter.java
+++ b/ikasaneip/sample/scheduleDrivenSrc/module/src/main/java/org/ikasan/sample/scheduleDrivenSrc/component/converter/ScheduleEventFailingConverter.java
@@ -40,6 +40,7 @@
  */
 package org.ikasan.sample.scheduleDrivenSrc.component.converter;
 
+import org.ikasan.spec.component.endpoint.EndpointException;
 import org.ikasan.spec.component.transformation.Converter;
 import org.ikasan.spec.component.transformation.TransformationException;
 import org.quartz.JobExecutionContext;
@@ -51,14 +52,23 @@ import org.quartz.JobExecutionContext;
  */
 public class ScheduleEventFailingConverter implements Converter<JobExecutionContext,StringBuilder>
 {
+    private volatile int invocationCount = 0;
+
     public StringBuilder convert(JobExecutionContext context) throws TransformationException
     {
+        invocationCount++;
         StringBuilder sb = new StringBuilder();
         sb.append("schedule executed at = ");
         sb.append(context.getFireTime());
         sb.append(" name = ");
         sb.append(context.getJobDetail().getKey().getName());
-        if(true) throw new TransformationException("test exception");
+        if(true) throw new EndpointException("test exception: " + invocationCount);
         return sb;
     }
+
+    public int getInvocationCount()
+    {
+        return invocationCount;
+    }
+
 }

--- a/ikasaneip/sample/scheduleDrivenSrc/module/src/main/resources/demo-exclusion-component-conf.xml
+++ b/ikasaneip/sample/scheduleDrivenSrc/module/src/main/resources/demo-exclusion-component-conf.xml
@@ -30,6 +30,6 @@
         </property>
     </bean>
 
-    <bean id="scheduledFailingConverter" class="org.ikasan.sample.scheduleDrivenSrc.component.converter.ScheduleEventFailingConverter" scope="prototype" />
+    <bean id="scheduledFailingConverter" class="org.ikasan.sample.scheduleDrivenSrc.component.converter.ScheduleEventFailingConverter" />
 
 </beans>

--- a/ikasaneip/sample/scheduleDrivenSrc/module/src/main/resources/demo-exclusion-component-conf.xml
+++ b/ikasaneip/sample/scheduleDrivenSrc/module/src/main/resources/demo-exclusion-component-conf.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd">
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
         
     <!--  ================================================================== -->
     <!--  Sample component implementations for testing                       -->
@@ -25,9 +25,9 @@
         </property>
         <property name="configuredResourceId" value="sample-demo-exclusion-scheduled-flow-consumer"/>
         <property name="configuration" ref="scheduledConsumerConfiguration"/>
-        <property name="managedEventIdentifierService">
+        <!--<property name="managedEventIdentifierService">
             <bean class="org.ikasan.sample.scheduleDrivenSrc.component.endpoint.SimpleEventIdentifierServiceImpl"/>
-        </property>
+        </property>-->
     </bean>
 
     <bean id="scheduledFailingConverter" class="org.ikasan.sample.scheduleDrivenSrc.component.converter.ScheduleEventFailingConverter" />

--- a/ikasaneip/sample/scheduleDrivenSrc/module/src/main/resources/exception-conf.xml
+++ b/ikasaneip/sample/scheduleDrivenSrc/module/src/main/resources/exception-conf.xml
@@ -23,7 +23,7 @@
 			        </constructor-arg>
 			        <constructor-arg>
 			            <bean class="org.ikasan.exceptionResolver.action.RetryAction">
-			                <property name="delay" value="30000"/>
+			                <property name="delay" value="1000"/>
 			            </bean>
 			        </constructor-arg>
 			    </bean>

--- a/ikasaneip/sample/scheduleDrivenSrc/module/src/test/java/org/ikasan/sample/scheduleDrivenPriceSrc/integrationTest/ScheduledFlowSampleTest.java
+++ b/ikasaneip/sample/scheduleDrivenSrc/module/src/test/java/org/ikasan/sample/scheduleDrivenPriceSrc/integrationTest/ScheduledFlowSampleTest.java
@@ -42,11 +42,15 @@ package org.ikasan.sample.scheduleDrivenPriceSrc.integrationTest;
 
 import javax.annotation.Resource;
 
+import org.ikasan.sample.scheduleDrivenSrc.component.converter.ScheduleEventFailingConverter;
 import org.ikasan.spec.flow.Flow;
 import org.ikasan.spec.module.Module;
+import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.quartz.SchedulerException;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.ikasan.platform.IkasanEIPTest;
@@ -72,11 +76,17 @@ import org.ikasan.platform.IkasanEIPTest;
         "/configuration-service-conf.xml",
         "/hsqldb-conf.xml"
       })
-      
+@DirtiesContext
 public class ScheduledFlowSampleTest extends IkasanEIPTest
 {
     @Resource
     Module<Flow> module;
+
+    @Resource
+    private Flow demoExclusionScheduledConverterFlow;
+
+    @Resource
+    private ScheduleEventFailingConverter scheduleEventFailingConverter;
     
     @Test
     public void test_flow_consumer_translator_producer() throws SchedulerException
@@ -99,5 +109,27 @@ public class ScheduledFlowSampleTest extends IkasanEIPTest
         {
             flow.stop();
         }
+    }
+
+    @Test
+    @Ignore
+    public void test_recovery_flow() throws InterruptedException
+    {
+
+        demoExclusionScheduledConverterFlow.start();
+
+        Thread.sleep(7000L);
+
+        //Assert.assertEquals("recovering", demoExclusionScheduledConverterFlow.getState());
+        //Assert.assertEquals(2, scheduleEventFailingConverter.getInvocationCount());
+        demoExclusionScheduledConverterFlow.stop();
+        Assert.assertEquals("stopped", demoExclusionScheduledConverterFlow.getState());
+
+
+        Thread.sleep(7000L);
+        //Assert.assertEquals("stopped", demoExclusionScheduledConverterFlow.getState());
+        // no more invocations
+        //Assert.assertEquals(2, scheduleEventFailingConverter.getInvocationCount());
+
     }
 }

--- a/ikasaneip/sample/scheduleDrivenSrc/module/src/test/java/org/ikasan/sample/scheduleDrivenPriceSrc/integrationTest/ScheduledFlowSampleTest.java
+++ b/ikasaneip/sample/scheduleDrivenSrc/module/src/test/java/org/ikasan/sample/scheduleDrivenPriceSrc/integrationTest/ScheduledFlowSampleTest.java
@@ -40,8 +40,7 @@
  */
 package org.ikasan.sample.scheduleDrivenPriceSrc.integrationTest;
 
-import javax.annotation.Resource;
-
+import org.ikasan.platform.IkasanEIPTest;
 import org.ikasan.sample.scheduleDrivenSrc.component.converter.ScheduleEventFailingConverter;
 import org.ikasan.spec.flow.Flow;
 import org.ikasan.spec.module.Module;
@@ -53,7 +52,8 @@ import org.quartz.SchedulerException;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.ikasan.platform.IkasanEIPTest;
+
+import javax.annotation.Resource;
 
 /**
  * Test class for <code>PriceFlowSample</code>.
@@ -120,14 +120,14 @@ public class ScheduledFlowSampleTest extends IkasanEIPTest
 
         Thread.sleep(7000L);
 
-        //Assert.assertEquals("recovering", demoExclusionScheduledConverterFlow.getState());
+        Assert.assertEquals("recovering", demoExclusionScheduledConverterFlow.getState());
         //Assert.assertEquals(2, scheduleEventFailingConverter.getInvocationCount());
         demoExclusionScheduledConverterFlow.stop();
         Assert.assertEquals("stopped", demoExclusionScheduledConverterFlow.getState());
 
 
         Thread.sleep(7000L);
-        //Assert.assertEquals("stopped", demoExclusionScheduledConverterFlow.getState());
+        Assert.assertEquals("stopped", demoExclusionScheduledConverterFlow.getState());
         // no more invocations
         //Assert.assertEquals(2, scheduleEventFailingConverter.getInvocationCount());
 

--- a/ikasaneip/spec/component/src/main/java/org/ikasan/spec/component/endpoint/MultiThreadedCapable.java
+++ b/ikasaneip/spec/component/src/main/java/org/ikasan/spec/component/endpoint/MultiThreadedCapable.java
@@ -1,0 +1,50 @@
+/*
+ * $Id: Consumer.java 3531 2011-03-31 09:03:36Z mitcje $
+ * $URL: https://open.jira.com/svn/IKASAN/branches/ikasaneip-0.9.x/spec/component/endpoint/src/main/java/org/ikasan/spec/component/endpoint/Consumer.java $
+ *
+ * ====================================================================
+ * Ikasan Enterprise Integration Platform
+ *
+ * Distributed under the Modified BSD License.
+ * Copyright notice: The copyright for this software and a full listing
+ * of individual contributors are as shown in the packaged copyright.txt
+ * file.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  - Neither the name of the ORGANIZATION nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ */
+package org.ikasan.spec.component.endpoint;
+
+/**
+ * Marker interface for consumers that are capable of multi-threaded provision of messages, e.g. JmsConsumer
+ *
+ * @author Ikasan Development Teams
+ */
+public interface MultiThreadedCapable
+{
+}

--- a/ikasaneip/spec/recoveryManager/src/main/java/org/ikasan/spec/recovery/RecoveryManager.java
+++ b/ikasaneip/spec/recoveryManager/src/main/java/org/ikasan/spec/recovery/RecoveryManager.java
@@ -45,14 +45,14 @@ package org.ikasan.spec.recovery;
  * 
  * @author Ikasan Development Teams
  */
-public interface RecoveryManager<RESOLVER, CONTEXT>
+public interface RecoveryManager<RESOLVER, CONTEXT, ID>
 {
     /**
      * Set a resolver which translates the incoming exception and component name
      * in to an action to be taken by the recovery manager.
      * @param resolver
      */
-    public void setResolver(RESOLVER resolver);
+    void setResolver(RESOLVER resolver);
     
     /**
      * Set a resolver which translates the incoming exception and component name
@@ -60,13 +60,13 @@ public interface RecoveryManager<RESOLVER, CONTEXT>
      * @param managedResources
      * @param <MANAGED_RESOURCES>
      */
-    public <MANAGED_RESOURCES> void setManagedResources(MANAGED_RESOURCES managedResources);
+    <MANAGED_RESOURCES> void setManagedResources(MANAGED_RESOURCES managedResources);
     
     /**
      * Get the resolver for this recovery manager.
      * @return  resolver
      */
-    public RESOLVER getResolver();
+    RESOLVER getResolver();
 
     /**
      * Start or continue a recovery based on the passed CONTEXT
@@ -75,37 +75,43 @@ public interface RecoveryManager<RESOLVER, CONTEXT>
      * @param event
      * @param identifier
      * @param <EVENT>
-     * @param <IDENTIFIER>
+     * @param <ID>
      */
-    public <EVENT,IDENTIFIER> void recover(CONTEXT context, Throwable throwable, EVENT event, IDENTIFIER identifier);
+    <EVENT> void recover(CONTEXT context, Throwable throwable, EVENT event, ID identifier);
 
     /**
      * Start or continue a recovery based on the passed CRITERIA.
      * @param component
      * @param throwable
      */
-    public void recover(String component, Throwable throwable);
+    void recover(String component, Throwable throwable);
     
     /**
      * Is the recovery manager currently running a recovery.
      * @return
      */
-    public boolean isRecovering();
+    boolean isRecovering();
     
     /**
      * Is the recovery manager in an unrecoverable state.
      * @return
      */
-    public boolean isUnrecoverable();
+    boolean isUnrecoverable();
     
     /**
      * Cancel any recovery currently running in the recovery manager.
      */
-    public void cancel();
+    void cancelAll();
+
+    /**
+     * Cancel a recovery given the current identifier for a flow (flow event id)
+     * @param identifier the identifier
+     */
+    void cancel(ID identifier);
 
     /**
      * Initialize the state of the recovery manager clearing down any previously
      * held states resulting from previous executions.
      */
-    public void initialise();
+    void initialise();
 }


### PR DESCRIPTION
This needs a review since its a slightly different approach with capturing the LifeIds of recovering threads/messages.