### PR TITLE
2.0.x enforcer plugin

### DIFF
--- a/ikasaneip/configuration-service/pom.xml
+++ b/ikasaneip/configuration-service/pom.xml
@@ -213,12 +213,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>validation-api</artifactId>
-                    <groupId>javax.validation</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- logging -->

--- a/ikasaneip/dashboard/war/pom.xml
+++ b/ikasaneip/dashboard/war/pom.xml
@@ -131,6 +131,12 @@
 		   <groupId>com.github.vaadin4qbanos</groupId>
 		   <artifactId>jsclipboard</artifactId>
 		   <version>1.0.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-lang3</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 			
 		
@@ -371,30 +377,60 @@
 			<groupId>org.xwiki.rendering</groupId>
 			<artifactId>xwiki-rendering-syntax-xwiki21</artifactId>
 			<version>4.1.3</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-lang3</artifactId>
+				</exclusion>
+			</exclusions>
 	    </dependency>
 	    
 	    <dependency>
 			<groupId>org.xwiki.commons</groupId>
 			<artifactId>xwiki-commons-component-default</artifactId>
 			<version>4.1.3</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-lang3</artifactId>
+				</exclusion>
+			</exclusions>
 	    </dependency>
 	    
 	    <dependency>
 		      <groupId>org.xwiki.rendering</groupId>
 		      <artifactId>xwiki-rendering-macro-toc</artifactId>
 		      <version>4.1.3</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-lang3</artifactId>
+				</exclusion>
+			</exclusions>
 	    </dependency>
 	    
 	    <dependency>
-		      <groupId>org.xwiki.rendering</groupId>
-		      <artifactId>xwiki-rendering-macro-html</artifactId>
-		      <version>4.1.3</version>
+			<groupId>org.xwiki.rendering</groupId>
+			<artifactId>xwiki-rendering-macro-html</artifactId>
+			<version>4.1.3</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-lang3</artifactId>
+				</exclusion>
+			</exclusions>
 	    </dependency>
 	    
 	    <dependency>
 		   <groupId>com.vaadin.addon</groupId>
 		   <artifactId>vaadin-charts</artifactId>
 		   <version>2.1.3</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		
 		<!-- Test dependencies-->
@@ -403,6 +439,32 @@
 		   <groupId>com.vaadin</groupId>
 		   <artifactId>vaadin-testbench</artifactId>
 		   <scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-lang3</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.code.gson</groupId>
+					<artifactId>gson</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.yaml</groupId>
+					<artifactId>snakeyaml</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>net.sourceforge.cssparser</groupId>
+					<artifactId>cssparser</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>xml-apis</groupId>
+					<artifactId>xml-apis</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/ikasaneip/developer/mvn-archetype/ikasan-build-parent/pom.xml
+++ b/ikasaneip/developer/mvn-archetype/ikasan-build-parent/pom.xml
@@ -51,21 +51,11 @@
     <packaging>maven-plugin</packaging>
     <name>IkasanEIP Maven Archetype for a build parent</name>
 
-	
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-plugin-plugin</artifactId>
-			<version>3.2</version>
-		</dependency>
-	</dependencies>
-	
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
                 <configuration>
                     <goalPrefix>ikasan-build-parent</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/ikasaneip/developer/mvn-archetype/ikasan-jboss-6-activemq-im/pom.xml
+++ b/ikasaneip/developer/mvn-archetype/ikasan-jboss-6-activemq-im/pom.xml
@@ -56,20 +56,11 @@
         <activemq.url>tcp://localhost:61616</activemq.url>
     </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-plugin-plugin</artifactId>
-			<version>3.2</version>
-		</dependency>
-	</dependencies>
-	
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
                 <configuration>
                     <goalPrefix>ikasan-im-jboss</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/ikasaneip/developer/mvn-archetype/ikasan-jboss-6-db-im/pom.xml
+++ b/ikasaneip/developer/mvn-archetype/ikasan-jboss-6-db-im/pom.xml
@@ -51,20 +51,11 @@
     <packaging>maven-plugin</packaging>
     <name>IkasanEIP Maven Archetype for a Schedule Driven Database Integration Module</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-plugin-plugin</artifactId>
-			<version>3.2</version>
-		</dependency>
-	</dependencies>
-	
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
                 <configuration>
                     <goalPrefix>ikasan-im-jboss</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/ikasaneip/developer/mvn-archetype/ikasan-jboss-6-filesystem-im/pom.xml
+++ b/ikasaneip/developer/mvn-archetype/ikasan-jboss-6-filesystem-im/pom.xml
@@ -51,20 +51,12 @@
     <packaging>maven-plugin</packaging>
     <name>IkasanEIP Maven Archetype for a Schedule Driven Local File System Integration Module</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-plugin-plugin</artifactId>
-			<version>3.2</version>
-		</dependency>
-	</dependencies>
-	
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
                 <configuration>
                     <goalPrefix>ikasan-im-jboss</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/ikasaneip/developer/mvn-archetype/ikasan-jboss-6-jms-im/pom.xml
+++ b/ikasaneip/developer/mvn-archetype/ikasan-jboss-6-jms-im/pom.xml
@@ -51,20 +51,11 @@
     <packaging>maven-plugin</packaging>
     <name>IkasanEIP Maven Archetype for a JMS Integration Module</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-plugin-plugin</artifactId>
-			<version>3.2</version>
-		</dependency>
-	</dependencies>
-	
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
                 <configuration>
                     <goalPrefix>ikasan-im-jboss</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/ikasaneip/developer/mvn-archetype/ikasan-jboss-6-sftp-im/pom.xml
+++ b/ikasaneip/developer/mvn-archetype/ikasan-jboss-6-sftp-im/pom.xml
@@ -51,20 +51,11 @@
     <packaging>maven-plugin</packaging>
     <name>IkasanEIP Maven Archetype for a Schedule Driven SFTP Integration Module</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-plugin-plugin</artifactId>
-			<version>3.2</version>
-		</dependency>
-	</dependencies>
-	
-    <build>
+	<build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
                 <configuration>
                     <goalPrefix>ikasan-im-jboss</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/ikasaneip/developer/mvn-archetype/ikasan-rt-conf-jboss-6/pom.xml
+++ b/ikasaneip/developer/mvn-archetype/ikasan-rt-conf-jboss-6/pom.xml
@@ -35,20 +35,11 @@
 	<packaging>maven-plugin</packaging>
 	<name>IkasanEIP Maven Archetype for the Ikasan Runtime configuration within JBoss6</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-plugin-plugin</artifactId>
-			<version>3.2</version>
-		</dependency>
-	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.2</version>
 				<configuration>
 					<goalPrefix>ikasan-rt-conf-jboss</goalPrefix>
 					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/ikasaneip/developer/mvn-archetype/jboss-6-module-activemq/pom.xml
+++ b/ikasaneip/developer/mvn-archetype/jboss-6-module-activemq/pom.xml
@@ -51,21 +51,11 @@
     <packaging>maven-plugin</packaging>
     <name>IkasanEIP Maven Archetype for a Jboss module supporting ActiveMQ</name>
 
-	
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-plugin-plugin</artifactId>
-			<version>3.2</version>
-		</dependency>
-	</dependencies>
-	
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
                 <configuration>
                     <goalPrefix>jboss-module-activemq</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/ikasaneip/pom.xml
+++ b/ikasaneip/pom.xml
@@ -879,7 +879,7 @@
                 <module>developer</module>
                 <module>transaction</module>
                 <module>replay</module>
-                <!--<module>dashboard</module>-->
+                <module>dashboard</module>
                 <module>sample</module>
             </modules>
 
@@ -1667,6 +1667,12 @@
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-server</artifactId>
                 <version>${version.org.glassfish.jersey}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>validation-api</artifactId>
+                        <groupId>javax.validation</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/ikasaneip/pom.xml
+++ b/ikasaneip/pom.xml
@@ -427,6 +427,7 @@
         <version.org.apache.sshd>0.14.0</version.org.apache.sshd>
 		<version.org.glassfish.jersey>2.21</version.org.glassfish.jersey>
 		<version.org.glassfish.json>1.0</version.org.glassfish.json>
+		<version.com.fasterxml.jackson.core>2.5.4</version.com.fasterxml.jackson.core>
 		<version.javax.ws.rs>2.0</version.javax.ws.rs>
 		<version.com.zybnet.vaadin-autocomplete>1.1.1</version.com.zybnet.vaadin-autocomplete>
 		<version.vaadin>7.7.0</version.vaadin>
@@ -542,7 +543,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -677,9 +678,11 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
+
             </plugins>
         </pluginManagement>
         <plugins>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -692,6 +695,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <configuration>
+                    <rules><dependencyConvergence/></rules>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -726,6 +737,8 @@
                     </execution>
                 </executions>
             </plugin>
+
+
         </plugins>
     </build>
     <reporting>
@@ -866,9 +879,11 @@
                 <module>developer</module>
                 <module>transaction</module>
                 <module>replay</module>
-                <module>dashboard</module>
+                <!--<module>dashboard</module>-->
                 <module>sample</module>
             </modules>
+
+
         </profile>
 
         <profile>
@@ -884,6 +899,7 @@
                 <module>serialiser</module>
                 <module>exclusion</module>
                 <module>error-reporting</module>
+                <module>recovery-manager</module>
                 <module>recovery-manager</module>
                 <module>flow</module>
                 <module>configuration-service</module>
@@ -1535,6 +1551,12 @@
                 <groupId>com.io7m.xom</groupId>
                 <artifactId>xom</artifactId>
                 <version>${version.com.io7m.xom}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>xml-apis</groupId>
+                        <artifactId>xml-apis</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -1651,8 +1673,19 @@
                 <groupId>org.glassfish.jersey.media</groupId>
                 <artifactId>jersey-media-json-jackson</artifactId>
                 <version>${version.org.glassfish.jersey}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+				<version>${version.com.fasterxml.jackson.core}</version>
+            </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>
                 <artifactId>jersey-container-servlet</artifactId>
@@ -1866,6 +1899,23 @@
                 <groupId>org.apache.directory.server</groupId>
                 <artifactId>apacheds-server-unit</artifactId>
                 <version>${version.org.apache.directory.server.apached-server-unit}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.directory.server</groupId>
+                        <artifactId>apacheds-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.directory.server</groupId>
+                        <artifactId>apacheds-interceptor-kerberos</artifactId>
+
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.directory.server</groupId>
+                        <artifactId>apacheds-server-jndi</artifactId>
+                    </exclusion>
+
+                </exclusions>
+
             </dependency>
 
             <dependency>
@@ -2077,6 +2127,12 @@
                 <groupId>dom4j</groupId>
                 <artifactId>dom4j</artifactId>
                 <version>${version.dom4j.dom4j}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>xml-apis</groupId>
+                        <artifactId>xml-apis</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/ikasaneip/sample/jboss/ftp/jar/pom.xml
+++ b/ikasaneip/sample/jboss/ftp/jar/pom.xml
@@ -114,7 +114,6 @@
         <dependency>
             <groupId>org.mockftpserver</groupId>
             <artifactId>MockFtpServer</artifactId>
-            <version>2.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/ikasaneip/sample/jboss/sftp/jar/pom.xml
+++ b/ikasaneip/sample/jboss/sftp/jar/pom.xml
@@ -113,13 +113,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.mockftpserver</groupId>
-            <artifactId>MockFtpServer</artifactId>
-            <version>2.4</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
 </project>

--- a/ikasaneip/sample/spring-boot/jms/pom.xml
+++ b/ikasaneip/sample/spring-boot/jms/pom.xml
@@ -44,6 +44,21 @@
             <groupId>org.jboss</groupId>
             <artifactId>jboss-remote-naming</artifactId>
             <version>1.0.8.Final</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.xnio</groupId>
+                    <artifactId>xnio-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.marshalling</groupId>
+                    <artifactId>jboss-marshalling</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.remoting3</groupId>
+                    <artifactId>jboss-remoting</artifactId>
+                </exclusion>
+
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.jboss.xnio/xnio-nio -->
         <dependency>

--- a/ikasaneip/security/pom.xml
+++ b/ikasaneip/security/pom.xml
@@ -101,6 +101,10 @@
 					<artifactId>freemarker</artifactId>
 					<groupId>org.freemarker</groupId>
 				</exclusion>
+				<exclusion>
+					<artifactId>commons-pool</artifactId>
+					<groupId>commons-pool</groupId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -223,28 +227,24 @@
 		<dependency>
 		  <groupId>org.apache.directory.server</groupId>
 		  <artifactId>apacheds-server-integ</artifactId>
-		  <version>2.0.0-M18</version>
 		  <scope>provided</scope>
 		</dependency> 
 	 
 		<dependency>
 		  <groupId>org.apache.directory.server</groupId>
 		  <artifactId>apacheds-core-integ</artifactId>
-		  <version>2.0.0-M18</version>
 		  <scope>provided</scope>
 		</dependency> 
 
 		<dependency>
 		  <groupId>org.apache.directory.server</groupId>
 		  <artifactId>apacheds-server-unit</artifactId>
-		  <version>1.5.5</version>
 		  <scope>provided</scope>
 		</dependency> 
 
 		<dependency>
 			<groupId>com.unboundid</groupId>
 			<artifactId>unboundid-ldapsdk</artifactId>
-			<version>2.3.4</version>
 		</dependency>
 	 
 		<dependency>

--- a/ikasaneip/topology/pom.xml
+++ b/ikasaneip/topology/pom.xml
@@ -122,31 +122,30 @@
 		<dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>2.17</version>
         </dependency>
 
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.17</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
                 
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
-            <version>1.0</version>
         </dependency>
         
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-processing</artifactId>
-            <version>2.17</version>
         </dependency>
 
 		


### PR DESCRIPTION
A mvn enforcer lugin is enabled for all mvn builds. That means builds will start failing when dependencies with different versions are being pulled in.