### PR TITLE
IKASAN-1461 - fix for sub-route transitions refering to same route

### DIFF
--- a/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/EvaluationImpl.java
+++ b/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/EvaluationImpl.java
@@ -43,9 +43,6 @@ package org.ikasan.builder;
 import org.ikasan.builder.conditional.Otherwise;
 import org.ikasan.builder.conditional.When;
 import org.ikasan.flow.visitorPattern.FlowElementImpl;
-import org.ikasan.spec.flow.FlowElement;
-
-import java.util.List;
 
 /**
  * Implementation of the Evaluation contract for a Route being built through the builder pattern.
@@ -72,17 +69,19 @@ public class EvaluationImpl implements Evaluation<Route>
 
 	public Evaluation when(String name, Route evaluatedRoute)
 	{
-		List<FlowElement> fes = evaluatedRoute.getFlowElements();
-		fes.add(0, new FlowElementImpl(this.getClass().getName(), new When(name), null));
-		this.route.addNestedRoute(evaluatedRoute);
+        // create shallow copy of Route before adding When joining
+        Route shallowCopy = new RouteImpl(evaluatedRoute);
+        shallowCopy.addFlowElementAsFirst(new FlowElementImpl(this.getClass().getName(), new When(name), null));
+        this.route.addNestedRoute(shallowCopy);
 		return new EvaluationImpl(route);
 	}
 
 	public Evaluation<Route> otherwise(Route evaluatedRoute)
 	{
-		List<FlowElement> fes = evaluatedRoute.getFlowElements();
-		fes.add(0, new FlowElementImpl(this.getClass().getName(), new Otherwise(), null));
-		this.route.addNestedRoute(evaluatedRoute);
+		// create shallow copy of Route before adding Otherwise joining
+        Route shallowCopy = new RouteImpl(evaluatedRoute);
+        shallowCopy.addFlowElementAsFirst(new FlowElementImpl(this.getClass().getName(), new Otherwise(), null));
+        this.route.addNestedRoute(shallowCopy);
 		return new EvaluationImpl(route);
 	}
 

--- a/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/FlowBuilder.java
+++ b/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/FlowBuilder.java
@@ -950,17 +950,19 @@ public class FlowBuilder implements ApplicationContextAware
 
         public Evaluation<Flow> when(String name, Route evaluatedRoute)
         {
-            List<FlowElement> fes = evaluatedRoute.getFlowElements();
-            fes.add(0, new FlowElementImpl(this.getClass().getName(), new When(name), null));
-            this.route.addNestedRoute(evaluatedRoute);
+            // create shallow copy of Route before adding When joining
+            Route shallowCopy = new RouteImpl(evaluatedRoute);
+            shallowCopy.addFlowElementAsFirst(new FlowElementImpl(this.getClass().getName(), new When(name), null));
+            this.route.addNestedRoute(shallowCopy);
             return new PrimaryEvaluationImpl(route);
         }
 
         public Evaluation<Flow> otherwise(Route evaluatedRoute)
         {
-            List<FlowElement> fes = evaluatedRoute.getFlowElements();
-            fes.add(0, new FlowElementImpl(this.getClass().getName(), new Otherwise(), null));
-            this.route.addNestedRoute(evaluatedRoute);
+            // create shallow copy of Route before adding When joining
+            Route shallowCopy = new RouteImpl(evaluatedRoute);
+            shallowCopy.addFlowElementAsFirst(new FlowElementImpl(this.getClass().getName(), new Otherwise(), null));
+            this.route.addNestedRoute(shallowCopy);
             return new PrimaryEvaluationImpl(route);
         }
 

--- a/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/FlowBuilder.java
+++ b/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/FlowBuilder.java
@@ -959,7 +959,7 @@ public class FlowBuilder implements ApplicationContextAware
 
         public Evaluation<Flow> otherwise(Route evaluatedRoute)
         {
-            // create shallow copy of Route before adding When joining
+            // create shallow copy of Route before adding Otherwise joining
             Route shallowCopy = new RouteImpl(evaluatedRoute);
             shallowCopy.addFlowElementAsFirst(new FlowElementImpl(this.getClass().getName(), new Otherwise(), null));
             this.route.addNestedRoute(shallowCopy);
@@ -988,9 +988,10 @@ public class FlowBuilder implements ApplicationContextAware
 
         public Sequence<Flow> route(String name, Route sequencedRoute)
         {
-            List<FlowElement> fes = sequencedRoute.getFlowElements();
-            fes.add(0, new FlowElementImpl(this.getClass().getName(), SequentialOrder.to(name), null));
-            this.route.addNestedRoute(sequencedRoute);
+            // create shallow copy of Route before adding SequentialOrder joining
+            Route shallowCopy = new RouteImpl(sequencedRoute);
+            shallowCopy.addFlowElementAsFirst(new FlowElementImpl(this.getClass().getName(), SequentialOrder.to(name), null));
+            this.route.addNestedRoute(shallowCopy);
             return new PrimarySequenceImpl(route);
         }
 

--- a/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/Route.java
+++ b/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/Route.java
@@ -57,7 +57,13 @@ public interface Route
      */
 	public void addFlowElement(FlowElement flowElement);
 
-	/**
+    /**
+     * Add flow elements to the top of the route.
+     * @param flowElement
+     */
+    public void addFlowElementAsFirst(FlowElement flowElement);
+
+    /**
 	 * Add a nested route to the existing route.
 	 * @param route
      */

--- a/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/RouteImpl.java
+++ b/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/RouteImpl.java
@@ -66,10 +66,22 @@ public class RouteImpl implements Route
         nestedRoutes = new ArrayList<Route>();
     }
 
+    RouteImpl(Route existingRoute)
+    {
+        this.flowElements = new ArrayList<>(existingRoute.getFlowElements());
+
+        this.nestedRoutes = new ArrayList<>(existingRoute.getNestedRoutes());
+    }
+
     @Override
     public void addFlowElement(FlowElement flowElement)
     {
         this.flowElements.add(flowElement);
+    }
+
+    public void addFlowElementAsFirst(FlowElement flowElement)
+    {
+        this.flowElements.add(0,flowElement);
     }
 
     @Override

--- a/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/SequenceImpl.java
+++ b/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/SequenceImpl.java
@@ -66,9 +66,10 @@ public class SequenceImpl implements Sequence<Route>
 
 	public Sequence<Route> route(String name, Route sequencedRoute)
 	{
-		List<FlowElement> fes = sequencedRoute.getFlowElements();
-		fes.add(0, new FlowElementImpl(this.getClass().getName(), SequentialOrder.to(name), null));
-		this.route.addNestedRoute(sequencedRoute);
+        // create shallow copy of Route before adding SequentialOrder joining
+        Route shallowCopy = new RouteImpl(sequencedRoute);
+        shallowCopy.addFlowElementAsFirst(new FlowElementImpl(this.getClass().getName(), SequentialOrder.to(name), null));
+		this.route.addNestedRoute(shallowCopy);
 		return new SequenceImpl(route);
 	}
 

--- a/ikasaneip/builder/jar/src/test/java/org/ikasan/builder/FlowBuilderTest.java
+++ b/ikasaneip/builder/jar/src/test/java/org/ikasan/builder/FlowBuilderTest.java
@@ -1114,6 +1114,7 @@ public class FlowBuilderTest
                 .route("sequence name 1",
                         builderFactory.getRouteBuilder().sequencer("sequencerNested1",sequencer)
                                 .route("nestedSeq1", nestedRoute1)
+                                .route("nestedSeq1a", nestedRoute1)
                                 .route("nestedSeq2", nestedRoute2).build())
                 .route("sequence name 2", builderFactory.getRouteBuilder().producer("name3", producer))
                 .build();
@@ -1122,7 +1123,7 @@ public class FlowBuilderTest
         Assert.assertTrue("module name is incorrect", "moduleName".equals(flow.getModuleName()));
         List<FlowElement<?>> flowElements = flow.getFlowElements();
         Assert.assertNotNull("Flow elements cannot be 'null'", flowElements);
-        Assert.assertTrue("Should be 6 flow elements", flowElements.size() == 6);
+        Assert.assertTrue("Should be 6 flow elements was [" + flowElements.size() + "]", flowElements.size() == 7);
 
         // consumer
         FlowElement fe = flowElements.get(0);
@@ -1145,12 +1146,13 @@ public class FlowBuilderTest
         FlowElement feRoute1 = (FlowElement)fe.getTransitions().get("sequence name 1");
         Assert.assertTrue("flow element name should be 'sequencerNested1'", "sequencerNested1".equals(feRoute1.getComponentName()));
         Assert.assertTrue("flow element component should be an instance of Sequencer", feRoute1.getFlowComponent() instanceof Sequencer);
-        Assert.assertTrue("flow element should have two transitions", feRoute1.getTransitions().size() == 2);
+        Assert.assertTrue("flow element should have three transitions", feRoute1.getTransitions().size() == 3);
 
         // ensure sequence order
         ArrayList<String> nestedSequenceNames = new ArrayList<String>(feRoute1.getTransitions().keySet());
         Assert.assertTrue("flow element transition sequence should be in order of 'nestedSeq1'..." + " returned order is " + nestedSequenceNames, nestedSequenceNames.get(0).equals("nestedSeq1"));
-        Assert.assertTrue("flow element transition sequence should be in order of ...'sequence name 2'"  + " returned order is " + nestedSequenceNames, nestedSequenceNames.get(1).equals("nestedSeq2"));
+        Assert.assertTrue("flow element transition sequence should be in order of ...'sequence name 1a'"  + " returned order is " + nestedSequenceNames, nestedSequenceNames.get(1).equals("nestedSeq1a"));
+        Assert.assertTrue("flow element transition sequence should be in order of ...'sequence name 2'"  + " returned order is " + nestedSequenceNames, nestedSequenceNames.get(2).equals("nestedSeq2"));
 
         // nested sequencer1 nestedSeq1
         FlowElement feNestedRoute1 = (FlowElement)feRoute1.getTransitions().get("nestedSeq1");


### PR DESCRIPTION
router conditions transitions referring to same route are not represented correctly on flow.

Fix by creating shallow copy of every NestedRoute