### PR TITLE
IKASAN-1522 - Use jackson to convert map to and from string in webconsole

### DIFF
--- a/ikasaneip/webconsole/jar/src/main/java/org/ikasan/web/converter/JacksonMapStringConverter.java
+++ b/ikasaneip/webconsole/jar/src/main/java/org/ikasan/web/converter/JacksonMapStringConverter.java
@@ -1,0 +1,107 @@
+/*
+ * $Id$
+ * $URL$
+ *
+ * ====================================================================
+ * Ikasan Enterprise Integration Platform
+ *
+ * Distributed under the Modified BSD License.
+ * Copyright notice: The copyright for this software and a full listing
+ * of individual contributors are as shown in the packaged copyright.txt
+ * file.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  - Neither the name of the ORGANIZATION nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ */
+package org.ikasan.web.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.binding.convert.converters.TwoWayConverter;
+import org.springframework.util.Assert;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Custom two-way converter for Map to String, uses a Jackson object mapper to write the Map as a JSON String
+ *
+ * @author Ikasan Development Team
+ */
+public class JacksonMapStringConverter implements TwoWayConverter
+{
+    private ObjectMapper objectMapper;
+
+    public JacksonMapStringConverter(ObjectMapper objectMapper)
+    {
+        Assert.notNull(objectMapper, "ObjectMapper cannot be null");
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Object convertSourceToTargetClass(Object source, Class<?> aClass) throws Exception
+    {
+        if (source == null)
+        {
+            return null;
+        }
+        return objectMapper.writeValueAsString(source);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object convertTargetToSourceClass(Object target, Class<?> aClass)
+        throws Exception
+    {
+        if (target == null)
+        {
+            return null;
+        }
+        Map map = objectMapper.readValue((String) target, Map.class);
+        Map<String, String> checkedMap = Collections.checkedMap(new HashMap<>(map.size()), String.class, String.class);
+        checkedMap.putAll(map);
+        return checkedMap;
+    }
+
+    @Override
+    public Class<?> getSourceClass()
+    {
+        return Map.class;
+    }
+
+    @Override
+    public Class<?> getTargetClass()
+    {
+        return String.class;
+    }
+
+    public void setObjectMapper(ObjectMapper objectMapper)
+    {
+        this.objectMapper = objectMapper;
+    }
+}

--- a/ikasaneip/webconsole/jar/src/main/java/org/ikasan/web/converter/SpringConverter.java
+++ b/ikasaneip/webconsole/jar/src/main/java/org/ikasan/web/converter/SpringConverter.java
@@ -49,7 +49,9 @@ import java.util.Map;
 /**
  * Custom converter for String into Map
  * @author Ikasan Development Team
+ * @deprecated Use <class>JacksonMapStringConverter</class>
  */
+@Deprecated
 public class SpringConverter implements Converter
 {
     /** Logger for this class */

--- a/ikasaneip/webconsole/jar/src/main/resources/springapp-servlet-boot.xml
+++ b/ikasaneip/webconsole/jar/src/main/resources/springapp-servlet-boot.xml
@@ -113,7 +113,9 @@
 
     <bean id="iconversionService" class="org.ikasan.web.service.SpringConversionService">
         <property name="converter">
-            <bean class="org.ikasan.web.converter.SpringConverter" />
+            <bean class="org.ikasan.web.converter.JacksonMapStringConverter" >
+                <constructor-arg ref="objectMapper" />
+            </bean>
         </property>
     </bean>
 

--- a/ikasaneip/webconsole/jar/src/test/java/org/ikasan/web/converter/JacksonMapStringConverterTest.java
+++ b/ikasaneip/webconsole/jar/src/test/java/org/ikasan/web/converter/JacksonMapStringConverterTest.java
@@ -1,0 +1,145 @@
+/*
+ * $Id$
+ * $URL$
+ *
+ * ====================================================================
+ * Ikasan Enterprise Integration Platform
+ *
+ * Distributed under the Modified BSD License.
+ * Copyright notice: The copyright for this software and a full listing
+ * of individual contributors are as shown in the packaged copyright.txt
+ * file.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  - Neither the name of the ORGANIZATION nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ */
+package org.ikasan.web.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit test class supporting <class>JacksonMapStringConverter</class>
+ *
+ * @author Ikasan Developmnet Team
+ */
+public class JacksonMapStringConverterTest
+{
+    private JacksonMapStringConverter uut;
+
+    @Before
+    public void setup()
+    {
+        uut = new JacksonMapStringConverter(new ObjectMapper());
+    }
+
+    /**
+     * Test null to map.
+     */
+    @Test
+    public void test_map_converter_with_null_value() throws Exception
+    {
+        Object result = uut.convertTargetToSourceClass(null, Map.class);
+        Assert.assertNull("result should be null", result);
+    }
+
+    /**
+     * Test string to map.
+     */
+    @Test
+    public void test_map_converter_with_valid_string() throws Exception
+    {
+        Object result = uut.convertTargetToSourceClass("{\"one\":\"1\",\"two\":\"2\",\"three\":\"3\"}", Map.class);
+        Assert.assertTrue("result should be an instance of a map", result instanceof Map);
+        Map<String, String> resultMap = (Map) result;
+        Assert.assertTrue("map contains entry for one", resultMap.get("one").equals(String.valueOf("1")));
+        Assert.assertTrue("map contains entry for two", resultMap.get("two").equals(String.valueOf("2")));
+        Assert.assertTrue("map contains entry for three", resultMap.get("three").equals(String.valueOf("3")));
+    }
+
+    /**
+     * Test string to map.
+     */
+    @Test
+    public void test_map_converter_with_one_null_value() throws Exception
+    {
+        Object result = uut.convertTargetToSourceClass("{\"one\":null,\"two\":\"2\",\"three\":\"3\"}", Map.class);
+        Assert.assertTrue("result should be an instance of a map", result instanceof Map);
+        Map<String, String> resultMap = (Map) result;
+        Assert.assertTrue("map contains entry for one", resultMap.get("one") == null);
+        Assert.assertTrue("map contains entry for two", resultMap.get("two").equals(String.valueOf("2")));
+        Assert.assertTrue("map contains entry for three", resultMap.get("three").equals(String.valueOf("3")));
+    }
+
+    /**
+     * Test string to map.
+     */
+    @Test
+    public void test_map_converter_with_one_entry() throws Exception
+    {
+        Object result = uut.convertTargetToSourceClass("{\"one\":\"1\"}", Map.class);
+        Assert.assertTrue("result should be an instance of a map", result instanceof Map);
+        Map<String, String> resultMap = (Map) result;
+        Assert.assertTrue("map contains entry for one", resultMap.get("one").equals(String.valueOf("1")));
+    }
+
+    /**
+     * Test string to map.
+     */
+    @Test
+    public void test_map_converter_with_no_fields() throws Exception
+    {
+        Object result = uut.convertTargetToSourceClass("{}", Map.class);
+        Assert.assertTrue("result should be an instance of a map", result instanceof Map);
+        Map<String, String> resultMap = (Map) result;
+        Assert.assertTrue("map contains entry for one", resultMap.size() == 0);
+    }
+
+    /**
+     * Test string to map.
+     */
+    @Test(expected = ClassCastException.class)
+    public void test_map_converter_with_non_string_value() throws Exception
+    {
+        uut.convertTargetToSourceClass("{\"one\":\"1\",\"two\":true,\"three\":\"3\"}", Map.class);
+    }
+
+    @Test
+    public void test_map_converter_map_to_string() throws Exception
+    {
+        Map<String, String> map = new HashMap<>();
+        map.put("key", "{\"one\":{\"$gt \":\"50\",\"$lte\":\"100\"}}");
+        Object result = uut.convertSourceToTargetClass(map, String.class);
+        Assert.assertEquals("{\"key\":\"{\\\"one\\\":{\\\"$gt \\\":\\\"50\\\",\\\"$lte\\\":\\\"100\\\"}}\"}", result);
+    }
+}

--- a/ikasaneip/webconsole/war/src/main/webapp/WEB-INF/springapp-servlet.xml
+++ b/ikasaneip/webconsole/war/src/main/webapp/WEB-INF/springapp-servlet.xml
@@ -129,7 +129,9 @@
 
     <bean id="conversionService" class="org.ikasan.web.service.SpringConversionService">
         <property name="converter">
-            <bean class="org.ikasan.web.converter.SpringConverter" />
+            <bean class="org.ikasan.web.converter.JacksonMapStringConverter" >
+                <constructor-arg ref="objectMapper" />
+            </bean>
         </property>
     </bean>
 


### PR DESCRIPTION
I think using Jackson would be a good way to solve web console map serialization issues. Testing manually this works great but the format of the map would change to a JSON style on the front end, so users would have to be aware of that, e.g. -

map{one=1, two=2}

now becomes 

{"one":"1","two":"2"}

Every value in the map must be a String or the converter throws an error to avoid problems further downstream.

This change does not affect how config maps are stored in the db, only how they are displayed on the front end.

Please let me know if you think this would be appropriate.
