### PR TITLE
IKASAN-1550 - get rid of 'Hibernate's legacy org.hibernate.Criteria API'

### DIFF
--- a/ikasaneip/error-reporting/src/main/java/org/ikasan/error/reporting/dao/HibernateErrorCategorisationDao.java
+++ b/ikasaneip/error-reporting/src/main/java/org/ikasan/error/reporting/dao/HibernateErrorCategorisationDao.java
@@ -172,7 +172,7 @@ public class HibernateErrorCategorisationDao extends HibernateDaoSupport impleme
 	@Override
 	public List<ErrorCategorisation> findAll()
 	{
-        return getHibernateTemplate().loadAll(ErrorCategorisation.class);
+        return getHibernateTemplate().execute(session -> session.createQuery("from ErrorCategorisation").getResultList());
 	}
 	
 	/* (non-Javadoc)
@@ -181,7 +181,7 @@ public class HibernateErrorCategorisationDao extends HibernateDaoSupport impleme
 	@Override
 	public List<ErrorCategorisationLink> findAllErrorCategorisationLinks()
 	{
-        return getHibernateTemplate().loadAll(ErrorCategorisationLink.class);
+        return getHibernateTemplate().execute(session -> session.createQuery("from ErrorCategorisationLink").getResultList());
 	}
 
 	/* (non-Javadoc)

--- a/ikasaneip/security/src/main/java/org/ikasan/security/dao/HibernateAuthorityDao.java
+++ b/ikasaneip/security/src/main/java/org/ikasan/security/dao/HibernateAuthorityDao.java
@@ -59,7 +59,7 @@ public class HibernateAuthorityDao extends HibernateDaoSupport implements Author
     @SuppressWarnings("unchecked")
     public List<Authority> getAuthorities()
     {
-        return getHibernateTemplate().loadAll(Authority.class);
+        return getHibernateTemplate().execute(session -> session.createQuery("from Authority").getResultList());
     }
 
     /* (non-Javadoc)

--- a/ikasaneip/security/src/main/java/org/ikasan/security/dao/HibernateUserDao.java
+++ b/ikasaneip/security/src/main/java/org/ikasan/security/dao/HibernateUserDao.java
@@ -77,7 +77,7 @@ public class HibernateUserDao extends HibernateDaoSupport implements UserDao
     @SuppressWarnings("unchecked")
     public List<User> getUsers()
     {
-        return getHibernateTemplate().loadAll(User.class);
+        return getHibernateTemplate().execute(session -> session.createQuery("from User").getResultList());
     }
 
     /* (non-Javadoc)
@@ -86,7 +86,7 @@ public class HibernateUserDao extends HibernateDaoSupport implements UserDao
     @SuppressWarnings("unchecked")
     public List<UserLite> getUserLites()
     {
-        return getHibernateTemplate().loadAll(UserLite.class);
+        return getHibernateTemplate().execute(session -> session.createQuery("from UserLite").getResultList());
     }
 
     public void save(User user)

--- a/ikasaneip/topology/src/main/java/org/ikasan/topology/dao/HibernateTopologyDao.java
+++ b/ikasaneip/topology/src/main/java/org/ikasan/topology/dao/HibernateTopologyDao.java
@@ -92,7 +92,7 @@ public class HibernateTopologyDao extends HibernateDaoSupport implements Topolog
 	@Override
 	public List<Server> getAllServers()
 	{
-		return getHibernateTemplate().loadAll(Server.class);
+        return getHibernateTemplate().execute( session -> session.createQuery("from Server").getResultList());
 	}
 
 	/* (non-Javadoc)
@@ -112,8 +112,8 @@ public class HibernateTopologyDao extends HibernateDaoSupport implements Topolog
 	@Override
 	public List<Module> getAllModules()
 	{
-        return getHibernateTemplate().loadAll(Module.class);
-	}
+        return getHibernateTemplate().execute( session -> session.createQuery("from Module").getResultList());
+    }
 
 	/* (non-Javadoc)
 	 * @see org.ikasan.topology.dao.TopologyDao#save(org.ikasan.topology.window.Module)
@@ -138,13 +138,13 @@ public class HibernateTopologyDao extends HibernateDaoSupport implements Topolog
 	@Override
 	public List<Flow> getAllFlows()
 	{
-        return getHibernateTemplate().loadAll(Flow.class);
+        return getHibernateTemplate().execute( session -> session.createQuery("from Flow").getResultList());
 	}
 
 	@Override
 	public List<Component> getAllComponents()
 	{
-		return getHibernateTemplate().loadAll(Component.class);
+		return getHibernateTemplate().execute( session -> session.createQuery("from Component").getResultList());
 	}
 
 	/* (non-Javadoc)
@@ -164,7 +164,7 @@ public class HibernateTopologyDao extends HibernateDaoSupport implements Topolog
 	@Override
 	public List<BusinessStream> getAllBusinessStreams()
 	{
-		return getHibernateTemplate().loadAll(BusinessStream.class);
+        return getHibernateTemplate().execute(session -> session.createQuery("from BusinessStream").getResultList());
 	}
 
 	/* (non-Javadoc)
@@ -512,8 +512,7 @@ public class HibernateTopologyDao extends HibernateDaoSupport implements Topolog
 	@Override
 	public List<Filter> getAllFilters()
 	{
-		return getHibernateTemplate().loadAll(Filter.class);
-
+		return getHibernateTemplate().execute(session -> session.createQuery("from Filter").getResultList());
     }
 
 	/* (non-Javadoc)
@@ -669,7 +668,7 @@ public class HibernateTopologyDao extends HibernateDaoSupport implements Topolog
 	@Override
 	public List<Notification> getAllNotifications()
 	{
-		 return getHibernateTemplate().loadAll(Notification.class);
+		 return getHibernateTemplate().execute(session -> session.createQuery("from Notification").getResultList());
     }
 
 

--- a/ikasaneip/wiretap/src/main/java/org/ikasan/trigger/dao/HibernateTriggerDao.java
+++ b/ikasaneip/wiretap/src/main/java/org/ikasan/trigger/dao/HibernateTriggerDao.java
@@ -73,7 +73,7 @@ public class HibernateTriggerDao extends HibernateDaoSupport implements TriggerD
     @SuppressWarnings("unchecked")
     public List<Trigger> findAll()
     {
-        return getHibernateTemplate().loadAll(Trigger.class);
+        return getHibernateTemplate().execute(session -> session.createQuery("from Trigger").getResultList());
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
IKASAN-1550 - get rid of 'Hibernate's legacy org.hibernate.Criteria API is deprecated; use the JPA javax.persistence.criteria.CriteriaQuery instead' by removing getHibernateTemplate().loadAll