### PR TITLE
#783 performance issue in SFTP/FTP file consuming

### DIFF
--- a/ikasaneip/component/endpoint/filetransfer/connector-basefiletransfer/pom.xml
+++ b/ikasaneip/component/endpoint/filetransfer/connector-basefiletransfer/pom.xml
@@ -73,6 +73,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
             <scope>provided</scope>

--- a/ikasaneip/component/endpoint/filetransfer/connector-basefiletransfer/src/test/java/org/ikasan/connector/basefiletransfer/outbound/command/FileDiscoveryCommandTest.java
+++ b/ikasaneip/component/endpoint/filetransfer/connector-basefiletransfer/src/test/java/org/ikasan/connector/basefiletransfer/outbound/command/FileDiscoveryCommandTest.java
@@ -47,6 +47,7 @@ import java.util.List;
 
 import javax.resource.ResourceException;
 
+import com.google.common.cache.CacheBuilder;
 import org.ikasan.connector.base.command.ExecutionContext;
 import org.ikasan.connector.base.command.ExecutionOutput;
 import org.ikasan.connector.base.command.XidImpl;
@@ -73,7 +74,7 @@ public class FileDiscoveryCommandTest
 {
     /**
      * Tests the execute method
-     * 
+     *
      * @throws ResourceException Exception thrown by Connector
      * @throws ClientCommandCdException Exception if we can't change directory
      * @throws ClientCommandLsException Exception if we can't list directory
@@ -123,24 +124,24 @@ public class FileDiscoveryCommandTest
                 will(returnValue(false));
             }
         });
-        
+
         final FileDiscoveryCommand command = new FileDiscoveryCommand(sourceDir,
-            filenamePattern, dao, 120, true, true, true, false);
-        
+                filenamePattern, dao, 120, true, true, true, false, false, false, CacheBuilder.newBuilder().build());
+
         final TransactionJournal transactionJournal = BaseFileTransferCommandJUnitHelper.getTransactionJournal(command, 3);
         command.setTransactionJournal(transactionJournal);
         ExecutionContext executionContext = new ExecutionContext();
         executionContext.put(ExecutionContext.CLIENT_ID, "clientId");
-        
+
         command.setExecutionContext(executionContext);
-        
+
         ExecutionOutput  output = command.execute(client, new XidImpl(new byte[0], new byte[0], 0));
         List<?> result = output.getResultList();
         assertNotNull("command result should not be null", result); //$NON-NLS-1$
         assertNotNull("command result should only contain one entry", result //$NON-NLS-1$
-            .size() == 1);
+                .size() == 1);
         assertEquals(
-            "command result's only entry should be the file that matches pattern", //$NON-NLS-1$
-            fileToDiscover, result.get(0));
+                "command result's only entry should be the file that matches pattern", //$NON-NLS-1$
+                fileToDiscover, result.get(0));
     }
 }

--- a/ikasaneip/component/endpoint/filetransfer/ftp/src/main/java/org/ikasan/connector/ftp/outbound/FTPManagedConnection.java
+++ b/ikasaneip/component/endpoint/filetransfer/ftp/src/main/java/org/ikasan/connector/ftp/outbound/FTPManagedConnection.java
@@ -47,6 +47,7 @@ import javax.resource.ResourceException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
+import com.google.common.cache.Cache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.ikasan.connector.base.command.TransactionalCommandConnection;
@@ -114,11 +115,30 @@ public class FTPManagedConnection extends TransactionalCommandConnection impleme
     /**
      * Create a virtual connection (a BaseFileTransferConnection object) and
      * add it to the list of managed instances before returning it to the client.
+     *
+     * @param fileChunkDao
+     * @param baseFileTransferDao
+     * @return
      */
-    public Object getConnection( FileChunkDao fileChunkDao, BaseFileTransferDao baseFileTransferDao)
+    public Object getConnection( FileChunkDao fileChunkDao, BaseFileTransferDao baseFileTransferDao, int testtodo) {
+        return getConnection(fileChunkDao, baseFileTransferDao, null);
+    }
+
+    /**
+     * Create a virtual connection (a BaseFileTransferConnection object) and
+     * add it to the list of managed instances before returning it to the client.
+     *
+     * @param fileChunkDao
+     * @param baseFileTransferDao
+     * @param duplicatesFileCache
+     * @return
+     */
+    public Object getConnection( FileChunkDao fileChunkDao, BaseFileTransferDao baseFileTransferDao,
+                                 Cache<String, Boolean> duplicatesFileCache)
     {
         logger.debug("Called getConnection()"); //$NON-NLS-1$
-        BaseFileTransferConnection connection = new FTPConnectionImpl(this, fileChunkDao, baseFileTransferDao);
+        BaseFileTransferConnection connection = new FTPConnectionImpl(this, fileChunkDao, baseFileTransferDao,
+            duplicatesFileCache);
         return connection;
     }
 

--- a/ikasaneip/component/endpoint/filetransfer/sftp/pom.xml
+++ b/ikasaneip/component/endpoint/filetransfer/sftp/pom.xml
@@ -66,6 +66,12 @@
             <artifactId>ikasan-quartz-endpoint</artifactId>
         </dependency>
 
+        <!-- Cache implementation -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
         <!-- Tests -->
         <dependency>
             <groupId>junit</groupId>

--- a/ikasaneip/component/endpoint/filetransfer/sftp/src/main/java/org/ikasan/connector/sftp/outbound/SFTPManagedConnection.java
+++ b/ikasaneip/component/endpoint/filetransfer/sftp/src/main/java/org/ikasan/connector/sftp/outbound/SFTPManagedConnection.java
@@ -40,6 +40,7 @@
  */
 package org.ikasan.connector.sftp.outbound;
 
+import com.google.common.cache.Cache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.ikasan.connector.BaseFileTransferConnection;
@@ -114,11 +115,31 @@ public class SFTPManagedConnection extends TransactionalCommandConnection implem
     /**
      * Create a virtual connection (a BaseFileTransferConnection object) and
      * add it to the list of managed instances before returning it to the client.
+     *
+     * @param fileChunkDao
+     * @param baseFileTransferDao
+     * @return
      */
     public Object getConnection( FileChunkDao fileChunkDao, BaseFileTransferDao baseFileTransferDao)
     {
+        return getConnection(fileChunkDao, baseFileTransferDao, null);
+    }
+
+    /**
+     * Create a virtual connection (a BaseFileTransferConnection object) and
+     * add it to the list of managed instances before returning it to the client.
+     *
+     * @param fileChunkDao
+     * @param baseFileTransferDao
+     * @param duplicatesFileCache
+     * @return
+     */
+    public Object getConnection( FileChunkDao fileChunkDao, BaseFileTransferDao baseFileTransferDao,
+                                 Cache<String, Boolean> duplicatesFileCache)
+    {
         logger.debug("Called getConnection()"); //$NON-NLS-1$
-        BaseFileTransferConnection connection = new SFTPConnectionImpl(this, fileChunkDao, baseFileTransferDao);
+        BaseFileTransferConnection connection = new SFTPConnectionImpl(this, fileChunkDao,
+            baseFileTransferDao, duplicatesFileCache);
         return connection;
     }
 


### PR DESCRIPTION
If the duplicate check is enabled then there is a performance issue with the SFTPConsumer (the SFTPMessageProvider and related classes).

Basically if the consumer wants to check for a new file and it first results in a list of x files, then it goes through all these files and calls an sql statement to detect if the file is a duplicate. Then it returns the whole filtered lists which gets sorted chronologically later (if enabled). Then it only takes the first file.

Now for the next file the whole process begins again. So e.g. if 4000 files should be consumed (eager = true), to find each next file to process all 4000 files are checked in the DB again and again.

This leads to a 11h of processing time e.g. in my tests with 4000 files, compared to about 1h after the fix.

The fix consists of
- not creating unnecessary String for disabled debug logging
- Allowing to cache the duplicate file info by making a Cache configurable
- Sort the files if needed as early as possible, so that we can skip unnecessary processing and directly return the first element, if only one is needed (which is currently the case anyway, as that get(0) is hard coded

Cache could have just been introduced in HibernateBaseFileTransferDaoImpl, or some other of the calling classes, but sadly most of them are instantiated hard coded. So to allow the module developer to easily set a cache for a flow I implemented the setting of a cache in the SFTPMessageProvider/FTPMessageProvider class.