### PR TITLE
fix h2 console rendering issue by setting X-Frame-Options to SameOrigin

### DIFF
--- a/ikasaneip/webconsole/jar/src/main/java/org/ikasan/web/WebSecurityConfig.java
+++ b/ikasaneip/webconsole/jar/src/main/java/org/ikasan/web/WebSecurityConfig.java
@@ -93,6 +93,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter
             .and()
             .logout().logoutSuccessUrl("/").logoutUrl("/j_spring_security_logout").deleteCookies("JSESSIONID")
             .and()
-            .csrf().disable();
+            .csrf().disable()
+            .headers().frameOptions().sameOrigin();
     }
 }


### PR DESCRIPTION
### Problem
H2 console was failed to render after we enabled it using the following configuration.

- spring.h2.console.enabled=true
- spring.h2.console.settings.web-allow-others=true

Details can be found in [H2-Console is not showing in browser](https://stackoverflow.com/questions/53395200/h2-console-is-not-showing-in-browser).

### Root Cause
Ikasan uses spring-security-config for securing web access. By default it sets **X-Frame-Options=Deny** so browser refuses to render any pages in frame.

Details can be found in [Accessing the Spring H2 database console when X-Frame-Options says deny](https://techsparx.com/software-development/spring/h2-console-frame-options.html) and [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options)

### Solution
Set **X-Frame-Options=SameOrigin** so that browser can render h2 console which belongs to the same origin.