### PR TITLE
IKASAN-1823 - BugFix where splitter is not correctly splitting events…

### DIFF
--- a/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/event/FlowEventFactory.java
+++ b/ikasaneip/flow/visitorPatternFlow/src/main/java/org/ikasan/flow/event/FlowEventFactory.java
@@ -69,7 +69,14 @@ public class FlowEventFactory implements EventFactory<FlowEvent<?,?>>
         return new GenericFlowEvent<>(identifier, relatedIdentifier, payload);
     }
 
-	/**
+    @Override
+    public <IDENTIFIER, PAYLOAD> FlowEvent<?, ?> newEvent(IDENTIFIER identifier, IDENTIFIER relatedIdentifier, long timestamp, PAYLOAD payload)
+    {
+        return new GenericFlowEvent<>(identifier, relatedIdentifier, timestamp, payload);
+    }
+
+
+    /**
 	 * Implementation of a flowEvent based on payload being of any generic type.
 	 * 
 	 * @author Ikasan Development Team
@@ -125,7 +132,26 @@ public class FlowEventFactory implements EventFactory<FlowEvent<?,?>>
             this.timestamp = System.currentTimeMillis();
             this.payload = payload;
         }
-        
+
+        /**
+         * Constructor
+         * @param identifier
+         * @param relatedIdentifier
+         * @param timestamp
+         * @param payload
+         */
+        protected GenericFlowEvent(ID identifier, ID relatedIdentifier, long timestamp, PAYLOAD payload)
+        {
+            this.identifier = identifier;
+            if(identifier == null)
+            {
+                throw new IllegalArgumentException("identifier cannot be 'null'. Make sure the FlowEvent has an identifier!");
+            }
+            this.relatedIdentifier = relatedIdentifier;
+            this.timestamp = timestamp;
+            this.payload = payload;
+        }
+
 		/**
 		 * Get immutable flow event identifier.
 		 * @return String - event identifier

--- a/ikasaneip/spec/event/src/main/java/org/ikasan/spec/event/EventFactory.java
+++ b/ikasaneip/spec/event/src/main/java/org/ikasan/spec/event/EventFactory.java
@@ -55,7 +55,7 @@ public interface EventFactory<EVENT>
      * @param payload - data content to be transported
      * @return EVENT
      */
-    public <IDENTIFIER,PAYLOAD> EVENT newEvent(IDENTIFIER identifier, PAYLOAD payload);
+    <IDENTIFIER,PAYLOAD> EVENT newEvent(IDENTIFIER identifier, PAYLOAD payload);
 
     /**
      * Create a new instance of an event with the provided identifier, related identifier, and payload.
@@ -64,5 +64,17 @@ public interface EventFactory<EVENT>
      * @param payload - data content to be transported
      * @return EVENT
      */
-    public <IDENTIFIER,PAYLOAD> EVENT newEvent(IDENTIFIER identifier, IDENTIFIER relatedIdentifier, PAYLOAD payload);
+    <IDENTIFIER,PAYLOAD> EVENT newEvent(IDENTIFIER identifier, IDENTIFIER relatedIdentifier, PAYLOAD payload);
+
+    /**
+     * Create a new instance of an event with the provided identifier, related identifier, timestamp, and payload.
+     * @param identifier
+     * @param relatedIdentifier
+     * @param timestamp
+     * @param payload
+     * @param <IDENTIFIER>
+     * @param <PAYLOAD>
+     * @return
+     */
+    <IDENTIFIER,PAYLOAD> EVENT newEvent(IDENTIFIER identifier, IDENTIFIER relatedIdentifier, long timestamp, PAYLOAD payload);
 }


### PR DESCRIPTION
… containing a single payload. Also added support for event instance meta-data to be effectively cloned ie identifier, relatedIdentifier were already covered, but timestamp was missed and hence changed on new instances of event.