### PR TITLE
Issue_948 Set hibernate.criteria.literal_handling_mode=BIND

### DIFF
--- a/ikasaneip/builder/jar/src/test/resources/datasource-conf.xml
+++ b/ikasaneip/builder/jar/src/test/resources/datasource-conf.xml
@@ -53,6 +53,7 @@
         <entry key="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
         <entry key="hibernate.show_sql" value="false"/>
         <entry key="hibernate.hbm2ddl.auto" value="none"/>
+        <entry key="hibernate.criteria.literal_handling_mode" value="BIND"/>
     </util:map>
     
     <bean id="dataSource" name="ikasan.xads ikasan.ds"

--- a/ikasaneip/platform/ikasan-standalone-persistence/src/main/resources/datasource-conf.xml
+++ b/ikasaneip/platform/ikasan-standalone-persistence/src/main/resources/datasource-conf.xml
@@ -14,6 +14,7 @@
         <entry key="hibernate.transaction.coordinator_class" value="jta" />
         <entry key="hibernate.transaction.jta.platform" value="JBossTS" />
         <entry key="hibernate.connection.autocommit" value="false" />
+        <entry key="hibernate.criteria.literal_handling_mode" value="BIND"/>
     </util:map>
 
     <bean id="ikasanDatasource" name="ikasan.ds" class="org.apache.commons.dbcp2.BasicDataSource">


### PR DESCRIPTION
Addresses #948 by setting hibernate.criteria.literal_handling_mode=BIND

This causes equivalently constructed CriteriaQuery instances which differ only in the actual value of one or more numeric parameters to be seen as discrete instances of the same Query.  The then appears only once in the QueryCache, and is re-used each time it is invoked.  

Without this change, each invocation with different Numeric parameter value(s) is seen as a discrete query, is individually stored in the QueryCache, uses excessive heap, and is essentially not re-used unless precisely the same Numeric parameters are passed to the CriteriaQuery on a subsequent invocation