### PR TITLE
Ikasan-948 (Backport to 3.0.x) Preserve CriteriaQuery placeholders in Hibernate Query Cache

### DIFF
--- a/ikasaneip/builder/jar/src/test/resources/datasource-conf.xml
+++ b/ikasaneip/builder/jar/src/test/resources/datasource-conf.xml
@@ -53,6 +53,7 @@
         <entry key="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
         <entry key="hibernate.show_sql" value="false"/>
         <entry key="hibernate.hbm2ddl.auto" value="none"/>
+        <entry key="hibernate.criteria.literal_handling_mode" value="BIND"/>
     </util:map>
     
     <bean id="dataSource" name="ikasan.xads ikasan.ds"

--- a/ikasaneip/platform/ikasan-standalone-persistence/src/main/resources/datasource-conf.xml
+++ b/ikasaneip/platform/ikasan-standalone-persistence/src/main/resources/datasource-conf.xml
@@ -14,6 +14,7 @@
         <entry key="hibernate.transaction.coordinator_class" value="jta" />
         <entry key="hibernate.transaction.jta.platform" value="JBossTS" />
         <entry key="hibernate.connection.autocommit" value="false" />
+        <entry key="hibernate.criteria.literal_handling_mode" value="BIND"/>
     </util:map>
 
     <bean id="ikasanDatasource" name="ikasan.ds" class="org.apache.commons.dbcp2.BasicDataSource">


### PR DESCRIPTION
Backport to 3.0.x of #955 