### PR TITLE
Enforce the order of otherwise(..) to the end of an evaluation statem…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     - [Developer Guide](ikasaneip/developer/docs/DeveloperGuide.md) 
     - [Component Guide](ikasaneip/component/Readme.md)
     - [Dashboard Guide](ikasaneip/visualisation/dashboard/README.md)
+    - [Upgrade Path](./UpgradePath.md) - steps required to upgrade from the previous Ikasan version
     
  - Samples overview
     - [spring-boot-builder-pattern](ikasaneip/sample/spring-boot/builder-pattern/README.md)

--- a/UpgradePath.md
+++ b/UpgradePath.md
@@ -1,0 +1,22 @@
+[![Build Status](https://travis-ci.org/ikasanEIP/ikasan.svg?branch=3.1.x)](https://travis-ci.org/ikasanEIP/ikasan)
+
+![Problem Domain](ikasaneip/developer/docs/quickstart-images/Ikasan-title-transparent.png)
+# Upgrade Path
+
+## Summary
+This document details the changes required to migrate from Ikasaneip-3.2.0 to Ikasaneip-3.3.0.
+This is not a comprehensive list of all changes in the release, but a guide to how to upgrade from one version to the next.
+
+## Required Changes
+
+### Builder Fluent API
+#### Change Summary
+Previous versions of the fluent API allowed for evaluation constructs such as ```when(..)``` and ```otherwise(..)``` to be specified in any order.
+To simplify and aid reading of the fluent API the ```otherwise(...)``` must now be the last construct, and no longer requires a further ```.build()``` specification to create the route.
+
+#### Upgrade Steps
+This change will potentially cause compilation errors on previous versions of Ikasan. 
+This can be resolved by simply re-ordering the ```otherwise(..)``` to be the last option 
+in the list of ```when(..)``` statements.
+
+Additionally, the ```.build()``` is not longer required and can be removed.

--- a/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/EvaluationOtherwise.java
+++ b/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/EvaluationOtherwise.java
@@ -60,5 +60,5 @@ public interface EvaluationOtherwise<T> extends Endpoint<T>
      * @param route
      * @return
      */
-    EvaluationOtherwise<T> otherwise(Route route);
+    T otherwise(Route route);
 }

--- a/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/EvaluationOtherwiseImpl.java
+++ b/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/EvaluationOtherwiseImpl.java
@@ -76,13 +76,13 @@ public class EvaluationOtherwiseImpl implements EvaluationOtherwise<Route>
 		return new EvaluationOtherwiseImpl(route);
 	}
 
-	public EvaluationOtherwise<Route> otherwise(Route evaluatedRoute)
+	public Route otherwise(Route evaluatedRoute)
 	{
 		// create shallow copy of Route before adding Otherwise joining
         Route shallowCopy = new RouteImpl(evaluatedRoute);
         shallowCopy.addFlowElementAsFirst(new FlowElementImpl(this.getClass().getName(), new Otherwise(), null));
         this.route.addNestedRoute(shallowCopy);
-		return new EvaluationOtherwiseImpl(route);
+		return this.build();
 	}
 
     /**

--- a/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/FlowBuilder.java
+++ b/ikasaneip/builder/jar/src/main/java/org/ikasan/builder/FlowBuilder.java
@@ -1467,13 +1467,13 @@ public class FlowBuilder implements ApplicationContextAware
             return new PrimaryEvaluationOtherwiseImpl(route);
         }
 
-        public EvaluationOtherwise<Flow> otherwise(Route evaluatedRoute)
+        public Flow otherwise(Route evaluatedRoute)
         {
             // create shallow copy of Route before adding Otherwise joining
             Route shallowCopy = new RouteImpl(evaluatedRoute);
             shallowCopy.addFlowElementAsFirst(new FlowElementImpl(this.getClass().getName(), new Otherwise(), null));
             this.route.addNestedRoute(shallowCopy);
-            return new PrimaryEvaluationOtherwiseImpl(route);
+            return this.build();
         }
 
         public Flow build()

--- a/ikasaneip/builder/jar/src/test/java/org/ikasan/builder/FlowBuilderTest.java
+++ b/ikasaneip/builder/jar/src/test/java/org/ikasan/builder/FlowBuilderTest.java
@@ -1206,7 +1206,7 @@ public class FlowBuilderTest
                 .singleRecipientRouter("router", singleRecipientRouter)
                 .when("route1", builderFactory.getRouteBuilder().producer("route1Publisher", producer))
                 .when("route2", builderFactory.getRouteBuilder().splitter("route2Splitter", splitter).producer("route2Publisher", producer))
-                .otherwise(builderFactory.getRouteBuilder().translator("otherwiseTranslator", translator).producer("otherwisePublisher", producer)).build();
+                .otherwise(builderFactory.getRouteBuilder().translator("otherwiseTranslator", translator).producer("otherwisePublisher", producer));
 
         Assert.assertTrue("flow name is incorrect", "flowName".equals(flow.getName()));
         Assert.assertTrue("module name is incorrect", "moduleName".equals(flow.getModuleName()));
@@ -1273,7 +1273,7 @@ public class FlowBuilderTest
             .singleRecipientRouter("router", singleRecipientRouter)
             .when("route1", builderFactory.getRouteBuilder().producer("route1Publisher", producer))
             .when("route2", builderFactory.getRouteBuilder().concurrentSplitter("route2Splitter", splitter).producer("route2Publisher", producer))
-            .otherwise(builderFactory.getRouteBuilder().translator("otherwiseTranslator", translator).producer("otherwisePublisher", producer)).build();
+            .otherwise(builderFactory.getRouteBuilder().translator("otherwiseTranslator", translator).producer("otherwisePublisher", producer));
 
         Assert.assertTrue("flow name is incorrect", "flowName".equals(flow.getName()));
         Assert.assertTrue("module name is incorrect", "moduleName".equals(flow.getModuleName()));
@@ -1344,8 +1344,7 @@ public class FlowBuilderTest
             .singleRecipientRouter("router", singleRecipientRouter)
             .when("route1", r1)
             .when("route1a", r1)
-            .otherwise(r2)
-            .build();
+            .otherwise(r2);
 
         Assert.assertTrue("flow name is incorrect", "flowName".equals(flow.getName()));
         Assert.assertTrue("module name is incorrect", "moduleName".equals(flow.getModuleName()));
@@ -1405,7 +1404,7 @@ public class FlowBuilderTest
         Route route2 = builderFactory.getRouteBuilder().singleRecipientRouter("nestedSRR", singleRecipientRouter)
                 .when("nestedRoute1", nestedRoute1)
                 .when("nestedRoute2", nestedRoute2)
-                .otherwise(nestedRoute3).build();
+                .otherwise(nestedRoute3);
 
         Flow flow = builderFactory.getFlowBuilder("moduleName", "flowName")
                 .withDescription("flowDescription")
@@ -1416,7 +1415,7 @@ public class FlowBuilderTest
                 .singleRecipientRouter("router", singleRecipientRouter)
                 .when("route1", builderFactory.getRouteBuilder().producer("whenPublisher1", producer))
                 .when("route2", route2)
-                .otherwise(builderFactory.getRouteBuilder().translator("otherwiseTranslator", translator).producer("otherwisePublisher", producer)).build();
+                .otherwise(builderFactory.getRouteBuilder().translator("otherwiseTranslator", translator).producer("otherwisePublisher", producer));
 
         Assert.assertTrue("flow name is incorrect", "flowName".equals(flow.getName()));
         Assert.assertTrue("module name is incorrect", "moduleName".equals(flow.getModuleName()));
@@ -1481,7 +1480,7 @@ public class FlowBuilderTest
         Route route2 = builderFactory.getRouteBuilder().singleRecipientRouter("nestedSRR", singleRecipientRouter)
             .when("nestedRoute1", nestedRoute1)
             .when("nestedRoute2", nestedRoute1)
-            .otherwise(nestedRoute1).build();
+            .otherwise(nestedRoute1);
 
         Flow flow = builderFactory.getFlowBuilder("moduleName", "flowName")
             .withDescription("flowDescription")
@@ -1492,7 +1491,7 @@ public class FlowBuilderTest
             .singleRecipientRouter("router", singleRecipientRouter)
             .when("route1", builderFactory.getRouteBuilder().producer("whenPublisher1", producer))
             .when("route2", route2)
-            .otherwise(builderFactory.getRouteBuilder().translator("otherwiseTranslator", translator).producer("otherwisePublisher", producer)).build();
+            .otherwise(builderFactory.getRouteBuilder().translator("otherwiseTranslator", translator).producer("otherwisePublisher", producer));
 
         Assert.assertTrue("flow name is incorrect", "flowName".equals(flow.getName()));
         Assert.assertTrue("module name is incorrect", "moduleName".equals(flow.getModuleName()));
@@ -1568,7 +1567,7 @@ public class FlowBuilderTest
         Route route2 = builderFactory.getRouteBuilder().singleRecipientRouter("nestedSRR", singleRecipientRouter)
                 .when("nestedRoute1", nestedRoute1)
                 .when("nestedRoute2", nestedRoute2)
-                .otherwise(nestedRoute3).build();
+                .otherwise(nestedRoute3);
 
         Flow flow = builderFactory.getFlowBuilder("moduleName", "flowName")
                 .withDescription("flowDescription")
@@ -1579,7 +1578,7 @@ public class FlowBuilderTest
                 .singleRecipientRouter("router", singleRecipientRouter)
                 .when("route1", route1)
                 .when("route2", route2)
-                .otherwise(builderFactory.getRouteBuilder().translator("name4", translator).producer("publisher4", producer)).build();
+                .otherwise(builderFactory.getRouteBuilder().translator("name4", translator).producer("publisher4", producer));
 
         Assert.assertTrue("flow name is incorrect", "flowName".equals(flow.getName()));
         Assert.assertTrue("module name is incorrect", "moduleName".equals(flow.getModuleName()));
@@ -1680,7 +1679,7 @@ public class FlowBuilderTest
                 .singleRecipientRouter("router", singleRecipientRouter)
                 .when("route1", route1)
                 .when("route2", route2)
-                .otherwise(builderFactory.getRouteBuilder().translator("name4", translator).producer("publisher4", producer)).build();
+                .otherwise(builderFactory.getRouteBuilder().translator("name4", translator).producer("publisher4", producer));
 
         Assert.assertTrue("flow name is incorrect", "flowName".equals(flow.getName()));
         Assert.assertTrue("module name is incorrect", "moduleName".equals(flow.getModuleName()));
@@ -1778,7 +1777,7 @@ public class FlowBuilderTest
                 .singleRecipientRouter("router", singleRecipientRouter)
                 .when("route1", route1)
                 .when("route2", route2)
-                .otherwise(builderFactory.getRouteBuilder().translator("name4", translator).producer("publisher4", producer)).build();
+                .otherwise(builderFactory.getRouteBuilder().translator("name4", translator).producer("publisher4", producer));
 
         Assert.assertTrue("flow name is incorrect", "flowName".equals(flow.getName()));
         Assert.assertTrue("module name is incorrect", "moduleName".equals(flow.getModuleName()));

--- a/ikasaneip/builder/jar/src/test/java/org/ikasan/sample/SampleFlowBuilderTest.java
+++ b/ikasaneip/builder/jar/src/test/java/org/ikasan/sample/SampleFlowBuilderTest.java
@@ -236,8 +236,7 @@ public class SampleFlowBuilderTest
 				.singleRecipientRouter("routerName", singleRecipientRouter)
 					.when("a", builderFactory.getRouteBuilder().producer("end1",producer) )
 					.when("b", builderFactory.getRouteBuilder().producer("end2",producer) )
-					.otherwise(builderFactory.getRouteBuilder().producer("end3",producer) )
-    	    	.build();
+					.otherwise(builderFactory.getRouteBuilder().producer("end3",producer) );
 
     	Assert.assertTrue("flow name is incorrect", "flowName".equals(flow.getName()));
     	Assert.assertTrue("module name is incorrect", "moduleName".equals(flow.getModuleName()));

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/MyFlowFactory.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/MyFlowFactory.java
@@ -80,8 +80,7 @@ public class MyFlowFactory implements FlowFactory
                 .producer("Scheduled Status Producer", componentFactory.getScheduledStatusProducer()))
             .otherwise(builderFactory.getRouteBuilder()
                 .filter("Publish Scheduled Status", componentFactory.getScheduledStatusFilter())
-                .producer("Blackout Scheduled Status Producer", componentFactory.getScheduledStatusProducer()))
-            .build();
+                .producer("Blackout Scheduled Status Producer", componentFactory.getScheduledStatusProducer()));
     }
 }
 


### PR DESCRIPTION
…ent. Makes the Fluent API more readable and removes cluster in terms of calling .build().

Added an UpgradePath.md detailing the changes required to accommodate this change when moving from ikasan 3.2.0 to 3.3.0.