### PR TITLE
Bug fix/3.2.1 ikasan 1992

### DIFF
--- a/ikasaneip/cli/shell/jar/src/main/java/org/ikasan/cli/shell/operation/DefaultOperationImpl.java
+++ b/ikasaneip/cli/shell/jar/src/main/java/org/ikasan/cli/shell/operation/DefaultOperationImpl.java
@@ -100,7 +100,7 @@ public class DefaultOperationImpl implements Operation
         {
             File outputLog = new File(processType.getOutputLog());
             FileUtil.createMissingParentDirectories(outputLog);
-            processBuilder.redirectOutput(outputLog);
+            processBuilder.redirectOutput(ProcessBuilder.Redirect.appendTo(outputLog));
         }
         if(processType.getErrorLog() == null || processType.getErrorLog().isEmpty())
         {
@@ -118,7 +118,7 @@ public class DefaultOperationImpl implements Operation
             {
                 File errorLog = new File(processType.getErrorLog());
                 FileUtil.createMissingParentDirectories(errorLog);
-                processBuilder.redirectError(errorLog);
+                processBuilder.redirectError(ProcessBuilder.Redirect.appendTo(errorLog));
             }
         }
 


### PR DESCRIPTION
Ikasan module application.log is recreated every time the JVM is started when using the CLI. PR onto a patvch version for 3.2.1