### PR TITLE
IKASAN-2128 Allow Proxy Setting in System Property for EmbeddedMongo …

### DIFF
--- a/ikasaneip/component/endpoint/mongo-endpoint-test/src/main/java/org/ikasan/component/endpoint/mongo/test/EmbeddedMongo.java
+++ b/ikasaneip/component/endpoint/mongo-endpoint-test/src/main/java/org/ikasan/component/endpoint/mongo/test/EmbeddedMongo.java
@@ -116,13 +116,13 @@ public class EmbeddedMongo
     }
 
     private void overrideConfigurationWithEnvironmentVariables() {
-        final String envCustomHttpProxyHost = System.getenv(EmbeddedMongoConfiguration.CUSTOM_HTTP_PROXY_HOST);
-        final String envCustomHttpProxyPort = System.getenv(EmbeddedMongoConfiguration.CUSTOM_HTTP_PROXY_PORT);
-        if (envCustomHttpProxyHost != null) {
-            configuration.setHttpProxyHost(envCustomHttpProxyHost);
+        final String envHttpProxyHost = System.getenv(EmbeddedMongoConfiguration.HTTP_PROXY_HOST);
+        final String envHttpProxyPort = System.getenv(EmbeddedMongoConfiguration.HTTP_PROXY_PORT);
+        if (envHttpProxyHost != null) {
+            configuration.setHttpProxyHost(envHttpProxyHost);
         }
-        if (envCustomHttpProxyPort != null) {
-            configuration.setHttpProxyPort(envCustomHttpProxyPort);
+        if (envHttpProxyPort != null) {
+            configuration.setHttpProxyPort(envHttpProxyPort);
         }
     }
 
@@ -133,8 +133,8 @@ public class EmbeddedMongo
         final String sysCustomMongoVersion=System.getProperty(EmbeddedMongoConfiguration.CUSTOM_MONGO_VERSION);
         final String sysCustomMongoArchiveStorageDir=System.getProperty(EmbeddedMongoConfiguration.CUSTOM_MONGO_ARCHIVE_STORAGE_DIRECTORY);
         final String sysCustomMongoPort=System.getProperty(EmbeddedMongoConfiguration.CUSTOM_MONGO_PORT);
-        final String sysCustomHttpProxyHost=System.getProperty(EmbeddedMongoConfiguration.CUSTOM_HTTP_PROXY_HOST);
-        final String sysCustomHttpProxyPort=System.getProperty(EmbeddedMongoConfiguration.CUSTOM_HTTP_PROXY_PORT);
+        final String sysHttpProxyHost=System.getProperty(EmbeddedMongoConfiguration.HTTP_PROXY_HOST);
+        final String sysHttpProxyPort=System.getProperty(EmbeddedMongoConfiguration.HTTP_PROXY_PORT);
         if (sysCustomMongoDatabaseDir != null){
             configuration.setDatabaseDirectory(sysCustomMongoDatabaseDir); 
         }
@@ -150,11 +150,11 @@ public class EmbeddedMongo
         if (sysCustomMongoPort != null){
             configuration.setPort(new Integer(sysCustomMongoPort));
         }
-        if (sysCustomHttpProxyHost != null){
-            configuration.setHttpProxyHost(sysCustomHttpProxyHost);
+        if (sysHttpProxyHost != null){
+            configuration.setHttpProxyHost(sysHttpProxyHost);
         }
-        if (sysCustomHttpProxyPort != null){
-            configuration.setHttpProxyPort(sysCustomHttpProxyPort);
+        if (sysHttpProxyPort != null){
+            configuration.setHttpProxyPort(sysHttpProxyPort);
         }
     }
 

--- a/ikasaneip/component/endpoint/mongo-endpoint-test/src/main/java/org/ikasan/component/endpoint/mongo/test/EmbeddedMongo.java
+++ b/ikasaneip/component/endpoint/mongo-endpoint-test/src/main/java/org/ikasan/component/endpoint/mongo/test/EmbeddedMongo.java
@@ -37,35 +37,30 @@
  */
 package org.ikasan.component.endpoint.mongo.test;
 
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
+import de.flapdoodle.embed.mongo.Command;
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodProcess;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.*;
+import de.flapdoodle.embed.mongo.distribution.Feature;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.mongo.distribution.Versions;
+import de.flapdoodle.embed.process.config.IRuntimeConfig;
+import de.flapdoodle.embed.process.config.store.HttpProxyFactory;
+import de.flapdoodle.embed.process.distribution.GenericVersion;
+import de.flapdoodle.embed.process.io.directories.IDirectory;
+import de.flapdoodle.embed.process.runtime.Network;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
-
-import de.flapdoodle.embed.mongo.Command;
-import de.flapdoodle.embed.mongo.MongodExecutable;
-import de.flapdoodle.embed.mongo.MongodProcess;
-import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.ArtifactStoreBuilder;
-import de.flapdoodle.embed.mongo.config.DownloadConfigBuilder;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
-import de.flapdoodle.embed.mongo.config.Net;
-import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
-import de.flapdoodle.embed.mongo.config.Storage;
-import de.flapdoodle.embed.mongo.distribution.Feature;
-import de.flapdoodle.embed.mongo.distribution.Version;
-import de.flapdoodle.embed.mongo.distribution.Versions;
-import de.flapdoodle.embed.process.config.IRuntimeConfig;
-import de.flapdoodle.embed.process.distribution.GenericVersion;
-import de.flapdoodle.embed.process.io.directories.IDirectory;
-import de.flapdoodle.embed.process.runtime.Network;
 
 /**
  * Allows the port and download location of the mongo distribution to be configured Also ensures that only a single
@@ -219,6 +214,14 @@ public class EmbeddedMongo
             logger.info("Custom mongo artifact storage dir set to [{}]", customMongoArchiveDownloadDirectory);
             builder.artifactStorePath(getIDirectory(customMongoArchiveDownloadDirectory));
         }
+
+        String proxyHostName = System.getProperty("http.proxyHost");
+        String proxyPortStr = System.getProperty("http.proxyPort");
+        if (StringUtils.isNoneBlank(proxyHostName, proxyPortStr)) {
+            int proxyPort = Integer.parseInt(proxyPortStr);
+            builder.proxyFactory(new HttpProxyFactory(proxyHostName, proxyPort));
+        }
+
         return builder;
     }
 

--- a/ikasaneip/component/endpoint/mongo-endpoint-test/src/main/java/org/ikasan/component/endpoint/mongo/test/EmbeddedMongoConfiguration.java
+++ b/ikasaneip/component/endpoint/mongo-endpoint-test/src/main/java/org/ikasan/component/endpoint/mongo/test/EmbeddedMongoConfiguration.java
@@ -55,9 +55,9 @@ public class EmbeddedMongoConfiguration
 
     public static final String CUSTOM_MONGO_PORT = "ikasan.flapdoodle.customMongoPort";
 
-    public static final String CUSTOM_HTTP_PROXY_HOST = "http.proxy.host";
+    public static final String HTTP_PROXY_HOST = "http.proxy.host";
 
-    public static final String CUSTOM_HTTP_PROXY_PORT = "http.proxy.port";
+    public static final String HTTP_PROXY_PORT = "http.proxy.port";
 
     private String distributionDirectory;
 

--- a/ikasaneip/component/endpoint/mongo-endpoint-test/src/main/java/org/ikasan/component/endpoint/mongo/test/EmbeddedMongoConfiguration.java
+++ b/ikasaneip/component/endpoint/mongo-endpoint-test/src/main/java/org/ikasan/component/endpoint/mongo/test/EmbeddedMongoConfiguration.java
@@ -55,6 +55,10 @@ public class EmbeddedMongoConfiguration
 
     public static final String CUSTOM_MONGO_PORT = "ikasan.flapdoodle.customMongoPort";
 
+    public static final String CUSTOM_HTTP_PROXY_HOST = "http.proxy.host";
+
+    public static final String CUSTOM_HTTP_PROXY_PORT = "http.proxy.port";
+
     private String distributionDirectory;
 
     private String databaseDirectory;
@@ -64,6 +68,10 @@ public class EmbeddedMongoConfiguration
     private String version;
 
     private Integer port;
+
+    private String httpProxyHost;
+
+    private String httpProxyPort;
 
     public String getDistributionDirectory()
     {
@@ -129,11 +137,32 @@ public class EmbeddedMongoConfiguration
         this.port = port;
     }
 
+    public String getHttpProxyHost() {
+        return httpProxyHost;
+    }
+
+    public void setHttpProxyHost(String httpProxyHost) {
+        this.httpProxyHost = httpProxyHost;
+    }
+
+    public String getHttpProxyPort() {
+        return httpProxyPort;
+    }
+
+    public void setHttpProxyPort(String httpProxyPort) {
+        this.httpProxyPort = httpProxyPort;
+    }
+
     @Override
-    public String toString()
-    {
-        return "EmbeddedMongoConfiguration [distributionDirectory=" + distributionDirectory + ", databaseDirectory="
-                + databaseDirectory + ", archiveStorageDirectory=" + archiveStorageDirectory + ", version=" + version
-                + ", port=" + port + "]";
+    public String toString() {
+        return "EmbeddedMongoConfiguration{" +
+            "distributionDirectory='" + distributionDirectory + '\'' +
+            ", databaseDirectory='" + databaseDirectory + '\'' +
+            ", archiveStorageDirectory='" + archiveStorageDirectory + '\'' +
+            ", version='" + version + '\'' +
+            ", port=" + port +
+            ", httpProxyHost='" + httpProxyHost + '\'' +
+            ", httpProxyPort='" + httpProxyPort + '\'' +
+            '}';
     }
 }


### PR DESCRIPTION
### Background
Flow test fails to run when it needs Ikasan EmbeddedMongo because flapdoodle failed to download MongoDB runtime binary (https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.2.tgz) when the test run is behind proxy.

```build    26-Jul-2022 23:55:26    [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 21.261 s <<< FAILURE! - in a.b.c.FlowTest
build    26-Jul-2022 23:55:26    [ERROR] a.b.c.FlowTest.test_flow_when_irs_new  Time elapsed: 10.417 s  <<< ERROR!
build    26-Jul-2022 23:55:26    de.flapdoodle.embed.process.exceptions.DistributionException: prepare executable
build    26-Jul-2022 23:55:26        at a.b.c.FlowTest.setup(MurexOutIrsToMongoFlowTest.java:76)
build    26-Jul-2022 23:55:26    Caused by: java.io.IOException: Could not open inputStream for https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.2.tgz
build    26-Jul-2022 23:55:26        at a.b.c.FlowTest.setup(MurexOutIrsToMongoFlowTest.java:76)
build    26-Jul-2022 23:55:26    Caused by: java.net.SocketTimeoutException: connect timed out
build    26-Jul-2022 23:55:26        at a.b.c.FlowTest.setup(MurexOutIrsToMongoFlowTest.java:76)```

### Solution
Enhance EmbeddedMongo in mongo-endpoint-test to allow passing proxy details from system properties.
`mvn -Dtest=FlowTest#test_flow_when_irs_new test -Dhttp.proxyHost=<ProxyHostName> -Dhttp.proxyPort=<ProxyPort>`