### PR TITLE
Ikasan 2170 execution environment chooser

### DIFF
--- a/ikasaneip/ootb/rest/scheduler-agent-rest-module/src/main/java/org/ikasan/job/orchestration/model/job/InternalEventDrivenJobImpl.java
+++ b/ikasaneip/ootb/rest/scheduler-agent-rest-module/src/main/java/org/ikasan/job/orchestration/model/job/InternalEventDrivenJobImpl.java
@@ -17,6 +17,7 @@ public class InternalEventDrivenJobImpl extends SchedulerJobImpl implements Inte
     private List<Integer> daysOfWeekToRun;
     private boolean targetResidingContextOnly;
     private boolean participatesInLock;
+    private String executionEnvironmentProperties;
 
     @Override
     public List<String> getSuccessfulReturnCodes() {
@@ -109,6 +110,16 @@ public class InternalEventDrivenJobImpl extends SchedulerJobImpl implements Inte
     }
 
     @Override
+    public String getExecutionEnvironmentProperties() {
+        return executionEnvironmentProperties;
+    }
+
+    @Override
+    public void setExecutionEnvironmentProperties(String executionEnvironmentProperties) {
+        this.executionEnvironmentProperties = executionEnvironmentProperties;
+    }
+
+    @Override
     public String toString() {
         final StringBuffer sb = new StringBuffer("InternalEventDrivenJobImpl{");
         sb.append("successfulReturnCodes=").append(successfulReturnCodes);
@@ -132,6 +143,7 @@ public class InternalEventDrivenJobImpl extends SchedulerJobImpl implements Inte
         sb.append(", startupControlType='").append(startupControlType).append('\'');
         sb.append(", targetResidingContextOnly='").append(targetResidingContextOnly).append('\'');
         sb.append(", participatesInLock='").append(participatesInLock).append('\'');
+        sb.append(", executionEnvironmentProperties='").append(executionEnvironmentProperties).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/ikasaneip/ootb/rest/scheduler-agent-rest-module/src/main/java/org/ikasan/ootb/scheduler/agent/rest/dto/InternalEventDrivenJobInstanceDto.java
+++ b/ikasaneip/ootb/rest/scheduler-agent-rest-module/src/main/java/org/ikasan/ootb/scheduler/agent/rest/dto/InternalEventDrivenJobInstanceDto.java
@@ -33,6 +33,7 @@ public class InternalEventDrivenJobInstanceDto implements InternalEventDrivenJob
     private ScheduledProcessEvent scheduledProcessEvent;
     private boolean targetResidingContextOnly;
     private boolean participatesInLock;
+    private String executionEnvironmentProperties;
 
     private Map<String, Boolean> skippedContexts;
 
@@ -289,6 +290,16 @@ public class InternalEventDrivenJobInstanceDto implements InternalEventDrivenJob
     }
 
     @Override
+    public String getExecutionEnvironmentProperties() {
+        return executionEnvironmentProperties;
+    }
+
+    @Override
+    public void setExecutionEnvironmentProperties(String executionEnvironmentProperties) {
+        this.executionEnvironmentProperties = executionEnvironmentProperties;
+    }
+
+    @Override
     public String toString() {
         final StringBuffer sb = new StringBuffer("InternalEventDrivenJobDto{");
         sb.append("successfulReturnCodes=").append(successfulReturnCodes);
@@ -311,6 +322,7 @@ public class InternalEventDrivenJobInstanceDto implements InternalEventDrivenJob
         sb.append(", jobDescription='").append(jobDescription).append('\'');
         sb.append(", startupControlType='").append(startupControlType).append('\'');
         sb.append(", targetResidingContextOnly='").append(targetResidingContextOnly).append('\'');
+        sb.append(", executionEnvironmentProperties='").append(executionEnvironmentProperties).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/model/InternalEventDrivenJobInstanceImpl.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/model/InternalEventDrivenJobInstanceImpl.java
@@ -36,8 +36,8 @@ public class InternalEventDrivenJobInstanceImpl implements InternalEventDrivenJo
     private boolean targetResidingContextOnly;
     private boolean participatesInLock;
     private Map<String, Boolean> skippedContexts;
-
     private Map<String, Boolean> heldContexts;
+    private String executionEnvironmentProperties;
 
     @Override
     public List<String> getSuccessfulReturnCodes() {
@@ -287,6 +287,16 @@ public class InternalEventDrivenJobInstanceImpl implements InternalEventDrivenJo
     @Override
     public void setHeldContexts(Map<String, Boolean> heldContexts) {
         this.heldContexts = heldContexts;
+    }
+
+    @Override
+    public String getExecutionEnvironmentProperties() {
+        return executionEnvironmentProperties;
+    }
+
+    @Override
+    public void setExecutionEnvironmentProperties(String executionEnvironmentProperties) {
+        this.executionEnvironmentProperties = executionEnvironmentProperties;
     }
 
     @Override

--- a/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/instance/model/InternalEventDrivenJobInstance.java
+++ b/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/instance/model/InternalEventDrivenJobInstance.java
@@ -42,4 +42,22 @@ public interface InternalEventDrivenJobInstance extends SchedulerJobInstance, Se
     void setParticipatesInLock(boolean participatesInLock);
 
     boolean isParticipatesInLock();
+
+
+    /**
+     * An optional property to set how you want the getCommandLine to be executed, by default if the agent is
+     * deployed on a unix environment it will default to Bash, windows it will default to cmd.
+     * @return
+     */
+    String getExecutionEnvironmentProperties();
+
+    /**
+     * An optional property to set how you want the getCommandLine to be executed, by default if the agent is
+     * deployed on a unix environment it will default to Bash, windows it will default to cmd.
+     *
+     * To set, passing a pipe delimited string to represent the String array that represent the commands that will be
+     * used by the java.lang.ProcessBuilder to set how we want to execute the script from getCommandLine
+     * @return
+     */
+    void setExecutionEnvironmentProperties(String executionEnvironmentProperties);
 }

--- a/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/job/model/InternalEventDrivenJob.java
+++ b/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/job/model/InternalEventDrivenJob.java
@@ -41,4 +41,21 @@ public interface InternalEventDrivenJob extends SchedulerJob, Serializable {
     void setParticipatesInLock(boolean participatesInLock);
 
     boolean isParticipatesInLock();
+
+    /**
+     * An optional property to set how you want the getCommandLine to be executed, by default if the agent is
+     * deployed on a unix environment it will default to Bash, windows it will default to cmd.
+     * @return
+     */
+    String getExecutionEnvironmentProperties();
+
+    /**
+     * An optional property to set how you want the getCommandLine to be executed, by default if the agent is
+     * deployed on a unix environment it will default to Bash, windows it will default to cmd.
+     *
+     * To set, passing a pipe delimited string to represent the String array that represent the commands that will be
+     * used by the java.lang.ProcessBuilder to set how we want to execute the script from getCommandLine
+     * @return
+     */
+    void setExecutionEnvironmentProperties(String executionEnvironmentProperties);
 }

--- a/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/notification/model/Monitor.java
+++ b/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/notification/model/Monitor.java
@@ -82,4 +82,10 @@ import java.util.List;
      * Newly created contextInstance registers itself to Monitor .
      */
     void register(ContextInstance contextInstance);
+
+    /**
+     * Remove the contextInstance from the Monitor .
+     */
+    void unregister(ContextInstance contextInstance);
+
 }


### PR DESCRIPTION
New attribute in internal job to define how to execute a job. Dashboard contains the predefine attribute which converts it for the agent.

Also added for notification a new "unregister" spec for Monitor. Implemented in the dashboard