### PR TITLE
Ikasan 2184 enable spring cloud encryption to context params

### DIFF
--- a/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/job/service/SpringCloudConfigRefreshService.java
+++ b/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/job/service/SpringCloudConfigRefreshService.java
@@ -17,6 +17,14 @@ public interface SpringCloudConfigRefreshService {
     void refreshConfigRepo(String contextUrl, String applicationPattern);
 
     /**
+     * Request config service to decrypt the value so we can read the values
+     * @param contextUrl url path to config service
+     * @param encryptedValue value you want to decrypt using Spring Cloud Config Service decryption
+     * @return decrypted value
+     */
+    String decrypt(String contextUrl, String encryptedValue);
+    
+    /**
      * Service to run the Spring Actuator Refresh
      */
     void actuatorRefresh();


### PR DESCRIPTION
IKASAN-2184 - spring cloud encryption for context params. Dashboard changes required.

IKASAN-2183 to handle issues with job running too long causing flow to StoppedInError. Also will attempt to kill the process currently running on the agent box so that when sending an event to scheduler it will terminate the job running as well.