### PR TITLE
IKASAN-2279-Shell-issue-with-old-instance-and-new-jar

### DIFF
--- a/ikasaneip/cli/shell/process-monitor/src/main/java/org/ikasan/cli/shell/operation/dao/KryoProcessPersistenceImpl.java
+++ b/ikasaneip/cli/shell/process-monitor/src/main/java/org/ikasan/cli/shell/operation/dao/KryoProcessPersistenceImpl.java
@@ -133,6 +133,10 @@ public class KryoProcessPersistenceImpl implements ProcessPersistenceDao
             logger.debug("File [" + path + "] not found", e);
             return null;
         }
+        catch(IndexOutOfBoundsException ioobe) {
+            logger.warn("An attempt to read the pid file has failed, if running new jars against old instance, this can be ignored");
+            return null;
+        }
     }
 
     @Override

--- a/ikasaneip/cli/shell/process-monitor/src/main/java/org/ikasan/cli/shell/operation/dao/KryoProcessPersistenceImpl.java
+++ b/ikasaneip/cli/shell/process-monitor/src/main/java/org/ikasan/cli/shell/operation/dao/KryoProcessPersistenceImpl.java
@@ -134,7 +134,7 @@ public class KryoProcessPersistenceImpl implements ProcessPersistenceDao
             return null;
         }
         catch(IndexOutOfBoundsException ioobe) {
-            logger.warn("An attempt to read the pid file has failed, if running new jars against old instance, this can be ignored");
+            logger.error("An attempt to read the pid file has failed, if running new jars against old instance, this can be ignored");
             return null;
         }
     }

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/boot/JobProcessingFlowFactory.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/boot/JobProcessingFlowFactory.java
@@ -74,7 +74,7 @@ public class JobProcessingFlowFactory
             .producer("Status Producer", componentFactory.getStatusProducer());
 
         Route monitorRoute = builderFactory.getRouteBuilder()
-            .broker("Job Monitoring Broker", componentFactory.getJobMonitoringBroker())
+            .broker("Job Monitoring Broker", componentFactory.getJobMonitoringBroker(jobName +" Job Processing Flow"))
             .producer("Status Producer", componentFactory.getStatusProducer());
 
         return builderFactory.getModuleBuilder(moduleName).getFlowBuilder(jobName)

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/boot/components/JobProcessingFlowComponentFactory.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/boot/components/JobProcessingFlowComponentFactory.java
@@ -104,6 +104,7 @@ import org.ikasan.spec.component.endpoint.Consumer;
 import org.ikasan.spec.component.endpoint.Producer;
 import org.ikasan.spec.component.routing.MultiRecipientRouter;
 import org.ikasan.spec.component.transformation.Converter;
+import org.ikasan.spec.error.reporting.ErrorReportingService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -152,6 +153,9 @@ public class JobProcessingFlowComponentFactory {
 
     @Resource
     BuilderFactory builderFactory;
+
+    @Resource
+    ErrorReportingService errorReportingService;
 
     String defaultPidDirectory = "." + FileSystems.getDefault().getSeparator() + "pid";
 
@@ -228,9 +232,9 @@ public class JobProcessingFlowComponentFactory {
      *
      * @return
      */
-    public Broker getJobMonitoringBroker()
+    public Broker getJobMonitoringBroker(String flowName)
     {
-        JobMonitoringBroker jobMonitoringBroker = new JobMonitoringBroker();
+        JobMonitoringBroker jobMonitoringBroker = new JobMonitoringBroker(this.errorReportingService, flowName);
 
         JobMonitoringBrokerConfiguration configuration = new JobMonitoringBrokerConfiguration();
         configuration.setTimeout(timeout);

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/broker/JobMonitoringBroker.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/broker/JobMonitoringBroker.java
@@ -105,7 +105,7 @@ public class JobMonitoringBroker implements Broker<EnrichedContextualisedSchedul
 
         try {
             // Process detached i.e. after agent restart, was still running.
-            LOGGER.info("Detached process" + scheduledProcessEvent.getDetachableProcess());
+            LOGGER.info("Detached process " + scheduledProcessEvent.getDetachableProcess());
 
             if (scheduledProcessEvent.getDetachableProcess().isDetached()) {
 
@@ -188,7 +188,7 @@ public class JobMonitoringBroker implements Broker<EnrichedContextualisedSchedul
             } catch (IOException ioe) {
                 LOGGER.warn("Attempt to tidy process and results file for " + scheduledProcessEvent.getJobName() +
                     " with identity " + scheduledProcessEvent.getDetachableProcess().getIdentity() +
-                    " failed, non fatal error but may require manual housekeeping of the agents pid directory", ioe);
+                    " failed, non fatal error but may require manual housekeeping of the agents pid directory", ioe.getMessage());
             }
         }
         catch(InterruptedException e) {

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/model/EnrichedContextualisedScheduledProcessEvent.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/model/EnrichedContextualisedScheduledProcessEvent.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public class EnrichedContextualisedScheduledProcessEvent extends ContextualisedScheduledProcessEventImpl {
     @JsonIgnore
-    private DetachableProcess detachableProcess;
+    private transient DetachableProcess detachableProcess;
 
     @JsonIgnore
     private List<ContextParameterInstance> contextParameters;

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/service/processtracker/DetachableProcess.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/service/processtracker/DetachableProcess.java
@@ -91,4 +91,18 @@ public class DetachableProcess {
     public void setDetachedAlreadyFinished(boolean detachedAlreadyFinished) {
         this.detachedAlreadyFinished = detachedAlreadyFinished;
     }
+
+    @Override
+    public String toString() {
+        return "DetachableProcess{" +
+            "schedulerPersistenceService=" + schedulerPersistenceService +
+            ", identity='" + identity + '\'' +
+            ", process=" + process +
+            ", processHandle=" + processHandle +
+            ", detached=" + detached +
+            ", detachedAlreadyFinished=" + detachedAlreadyFinished +
+            ", pid=" + pid +
+            ", commandProcessor=" + commandProcessor +
+            '}';
+    }
 }


### PR DESCRIPTION
We could downgrade the message to a warn, but the current filter in application.properties for shell messages only allow ERROR and above.