### PR TITLE
IKASAN-2347 index and PK name clashes causing issues on Azure DB. Hav…

### DIFF
--- a/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTChecksumCommand.xml
+++ b/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTChecksumCommand.xml
@@ -56,7 +56,7 @@
         <createTable tableName="FTChecksumCommand">
         
             <column name="Id" type="numeric(18)">
-                <constraints nullable="false"/>
+                <constraints nullable="false" primaryKey="true" primaryKeyName="FTChecksumCommandPK"/>
             </column>
             <column name="Destructive" type="BIT">
                 <constraints nullable="false"/>
@@ -67,10 +67,6 @@
         
         <!-- The statement below is required by sybase to set the identity gap to 1. -->
         <sql dbms="sybase">sp_chgattribute 'FTChecksumCommand', 'identity_gap', 1</sql>
-        
-        <createIndex indexName="FTChecksumCommand01u" tableName="FTChecksumCommand" unique="true">
-            <column name="Id"/>
-        </createIndex>
 
     </changeSet>
     

--- a/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTCleanupChunksCommand.xml
+++ b/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTCleanupChunksCommand.xml
@@ -56,7 +56,7 @@
         <createTable tableName="FTCleanupChunksCommand">
         
             <column name="Id" type="numeric(18)">
-                <constraints nullable="false"/>
+                <constraints nullable="false" primaryKey="true" primaryKeyName="FTCleanupChunksCommandPK"/>
             </column>
             <column name="FileChunkHeaderId" type="numeric(18)"/>
             
@@ -64,10 +64,6 @@
         
         <!-- The statement below is required by sybase to set the identity gap to 1. -->
         <sql dbms="sybase">sp_chgattribute 'FTCleanupChunksCommand', 'identity_gap', 1</sql>
-        
-        <createIndex indexName="FTCleanupChunksCommand01u" tableName="FTCleanupChunksCommand" unique="true">
-            <column name="Id"/>
-        </createIndex>
         
     </changeSet>
 

--- a/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTDeliverBatchCommand.xml
+++ b/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTDeliverBatchCommand.xml
@@ -56,7 +56,7 @@
         <createTable tableName="FTDeliverBatchCommand">
         
             <column name="Id" type="numeric(18)">
-                <constraints nullable="false"/>
+                <constraints nullable="false" primaryKey="true" primaryKeyName="FTDeliverBatchCommandPK"/>
             </column>
             <column name="OutputDirectory" type="VARCHAR(255)"/>
             <column name="TempDirectory" type="VARCHAR(255)"/>
@@ -69,10 +69,6 @@
         
         <!-- The statement below is required by sybase to set the identity gap to 1. -->
         <sql dbms="sybase">sp_chgattribute 'FTDeliverBatchCommand', 'identity_gap', 1</sql>
-        
-        <createIndex indexName="FTDeliverBatchCommand01u" tableName="FTDeliverBatchCommand" unique="true">
-            <column name="Id"/>
-        </createIndex>
 
     </changeSet>
 

--- a/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTDeliverFileCommand.xml
+++ b/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTDeliverFileCommand.xml
@@ -55,7 +55,7 @@
 
         <createTable tableName="FTDeliverFileCommand">
             <column name="Id" type="numeric(18)">
-                <constraints nullable="false"/>
+                <constraints nullable="false" primaryKey="true" primaryKeyName="FTDeliverFileCommandPK"/>
             </column>
             <column name="FileName" type="VARCHAR(255)"/>
             <column name="TempFileName" type="VARCHAR(255)"/>
@@ -70,10 +70,6 @@
         
         <!-- The statement below is required by sybase to set the identity gap to 1. -->
         <sql dbms="sybase">sp_chgattribute 'FTDeliverFileCommand', 'identity_gap', 1</sql>
-        
-        <createIndex indexName="FTDeliverFileCommand01u" tableName="FTDeliverFileCommand" unique="true">
-            <column name="Id"/>
-        </createIndex>
 
     </changeSet>
 

--- a/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTFileChunk.xml
+++ b/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTFileChunk.xml
@@ -56,7 +56,7 @@
         <createTable tableName="FTFileChunk">
         
             <column autoIncrement="${autoincrement}" name="Id" type="${identity}">
-                <constraints nullable="false" primaryKey="true" primaryKeyName="FTFileChunk01u"/>
+                <constraints nullable="false" primaryKey="true" primaryKeyName="FTFileChunkPK"/>
             </column>
             <column name="Content" type="IMAGE">
                 <constraints nullable="false"/>
@@ -73,10 +73,6 @@
         
         <!-- The statement below is required by sybase to set the identity gap to 1. -->
         <sql dbms="sybase">sp_chgattribute 'FTFileChunk', 'identity_gap', 1</sql>
-        
-        <createIndex indexName="FTFileChunk01u" tableName="FTFileChunk" unique="true">
-            <column name="Id"/>
-        </createIndex>
 
     </changeSet>
 

--- a/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTFileChunkHeader.xml
+++ b/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTFileChunkHeader.xml
@@ -56,7 +56,7 @@
         <createTable tableName="FTFileChunkHeader">
         
             <column autoIncrement="${autoincrement}" name="Id" type="${identity}">
-                <constraints nullable="false" primaryKey="true" primaryKeyName="FTFileChunkHeader01u"/>
+                <constraints nullable="false" primaryKey="true" primaryKeyName="FTFileChunkHeaderPK"/>
             </column>
             <column name="SequenceLength" type="numeric(18)">
                 <constraints nullable="false"/>
@@ -75,10 +75,6 @@
         
         <!-- The statement below is required by sybase to set the identity gap to 1. -->
         <sql dbms="sybase">sp_chgattribute 'FTFileChunkHeader', 'identity_gap', 1</sql>
-        
-        <createIndex indexName="FTFileChunkHeader01u" tableName="FTFileChunkHeader" unique="true">
-            <column name="Id"/>
-        </createIndex>
         
     </changeSet>
 

--- a/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTFileFilter.xml
+++ b/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTFileFilter.xml
@@ -56,7 +56,7 @@
         <createTable tableName="FTFileFilter">
         
             <column autoIncrement="${autoincrement}" name="Id" type="${identity}">
-                <constraints nullable="false" primaryKey="true" primaryKeyName="FTFileFilter01u"/>
+                <constraints nullable="false" primaryKey="true" primaryKeyName="FTFileFilter01PK"/>
             </column>
             <column name="ClientId" type="VARCHAR(255)">
                 <constraints nullable="false"/>
@@ -81,10 +81,6 @@
         
         <!-- The statement below is required by sybase to set the identity gap to 1. -->
         <sql dbms="sybase">sp_chgattribute 'FTFileFilter', 'identity_gap', 1</sql>
-        
-        <createIndex indexName="FTFileFilter01u" tableName="FTFileFilter" unique="true">
-            <column name="Id"/>
-        </createIndex>
         
         <createIndex indexName="FTFileFilter02u" tableName="FTFileFilter" unique="true">
             <column name="ClientId"/>

--- a/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTRetrieveFileCommand.xml
+++ b/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTRetrieveFileCommand.xml
@@ -56,7 +56,7 @@
         <createTable tableName="FTRetrieveFileCommand">
         
             <column name="Id" type="numeric(18)">
-                <constraints nullable="false"/>
+                <constraints nullable="false" primaryKey="true" primaryKeyName="FTRetrieveFileCommandPK"/>
             </column>
             <column name="Destructive" type="BIT">
                 <constraints nullable="false"/>
@@ -75,10 +75,6 @@
         
         <!-- The statement below is required by sybase to set the identity gap to 1. -->
         <sql dbms="sybase">sp_chgattribute 'FTRetrieveFileCommand', 'identity_gap', 1</sql>
-        
-        <createIndex indexName="FTRetrieveFileCommand01u" tableName="FTRetrieveFileCommand" unique="true">
-            <column name="Id"/>
-        </createIndex>
  
     </changeSet>
 

--- a/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTTransactionalResourceCommand.xml
+++ b/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTTransactionalResourceCommand.xml
@@ -56,7 +56,7 @@
         <createTable tableName="FTTransactionalResourceCommand">
         
             <column autoIncrement="${autoincrement}" name="Id" type="${identity}">
-                <constraints nullable="false" primaryKey="true" primaryKeyName="TransResCommand01u"/>
+                <constraints nullable="false" primaryKey="true" primaryKeyName="TransResCommandPK"/>
             </column>
             <column name="State" type="VARCHAR(255)">
                 <constraints nullable="false"/>
@@ -73,10 +73,6 @@
         
         <!-- The statement below is required by sybase to set the identity gap to 1. -->
         <sql dbms="sybase">sp_chgattribute 'FTTransactionalResourceCommand', 'identity_gap', 1</sql>
-        
-        <createIndex indexName="TransResCommand01u" tableName="FTTransactionalResourceCommand" unique="true">
-            <column name="Id"/>
-        </createIndex>
         
     </changeSet>
 

--- a/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTXid.xml
+++ b/ikasaneip/platform/ikasan-setup/src/main/resources/db/tables/db-changeLog-createFTXid.xml
@@ -56,7 +56,7 @@
         <createTable tableName="FTXid">
         
             <column autoIncrement="${autoincrement}" name="Id" type="${identity}">
-                <constraints nullable="false" primaryKey="true" primaryKeyName="FTXid01u"/>
+                <constraints nullable="false" primaryKey="true" primaryKeyName="FTXidPK"/>
             </column>
             <column name="State" type="VARCHAR(255)">
                 <constraints nullable="false"/>
@@ -84,10 +84,6 @@
         
         <!-- The statement below is required by sybase to set the identity gap to 1. -->
         <sql dbms="sybase">sp_chgattribute 'FTXid', 'identity_gap', 1</sql>
-        
-        <createIndex indexName="FTXid01u" tableName="FTXid" unique="true">
-            <column name="Id"/>
-        </createIndex>
 
 		<createIndex indexName="FTXid02u" tableName="FTXid" unique="true">
             <column name="GlobalTransactionId"/>


### PR DESCRIPTION
…e made PK definition consistent and removed indexes on the PKs as they become redundant and unique indexes provided and all PKs.