### PR TITLE
IKASAN-2374 Add ordinal attribute to maintain subcontext ordering whe…

### DIFF
--- a/ikasaneip/ootb/rest/scheduler-agent-rest-module/src/main/java/org/ikasan/job/orchestration/model/context/ContextImpl.java
+++ b/ikasaneip/ootb/rest/scheduler-agent-rest-module/src/main/java/org/ikasan/job/orchestration/model/context/ContextImpl.java
@@ -26,6 +26,7 @@ public class ContextImpl<CONTEXT extends Context, CONTEXT_PARAM, JOB extends Sch
     int treeViewExpandLevel = 1;
     private boolean ableToRunConcurrently;
     private boolean useDisplayName = false;
+    private int ordinal = -1;
 
     @Override
     public String getName() {
@@ -180,6 +181,16 @@ public class ContextImpl<CONTEXT extends Context, CONTEXT_PARAM, JOB extends Sch
     @Override
     public void setUseDisplayName(boolean useDisplayName) {
         this.useDisplayName = useDisplayName;
+    }
+
+    @Override
+    public int getOrdinal() {
+        return ordinal;
+    }
+
+    @Override
+    public void setOrdinal(int ordinal) {
+        this.ordinal = ordinal;
     }
 
     @Override

--- a/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/context/model/Context.java
+++ b/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/context/model/Context.java
@@ -284,4 +284,18 @@ public interface Context<CONTEXT extends Context, CONTEXT_PARAM, JOB extends Sch
      * @param ableToRunConcurrently
      */
     void setAbleToRunConcurrently(boolean ableToRunConcurrently);
+
+    /**
+     * Used to determine the order this contet has relative to other contexts when treated as a group of contexts
+     *
+     * @param ableToRunConcurrently
+     */
+    void setOrdinal(int ordinal);
+
+    /**
+     * Get the ordinal.
+     *
+     * @param ableToRunConcurrently
+     */
+    int getOrdinal();
 }


### PR DESCRIPTION
The new ordinals for the contexts are currently used during export and re-import only.