### PR TITLE
IKASAN-2410 sorting out the way that module names are associated with…

### DIFF
--- a/ikasaneip/cli/shell/jar/Readme.md
+++ b/ikasaneip/cli/shell/jar/Readme.md
@@ -146,7 +146,13 @@ Ikasan Shell:>
 | stop-solr    | Stop the Solr instance associated with the Ikasan Dashboard                                                                                                      | -name <Alternate Module Name>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 
 The configuration property `command.stop.process.wait.timeout.seconds` can be added to the application properties to configure a wait time for processes to stop. This has a default value of 300 seconds.
-The configuration property `h2.db.migration.module.name.persistence.directory.suffix` can be added to the properties of there is a suffix added to the module name for the database file location. The default is `-db`. 
+
+The configuration property `h2.db.migration.module.persistence.database.path` is mandatory. It is the full path to the default ESB database of the module. For example `/opt/data/my-module/db/esb` where 
+the database on the file system is `/opt/data/my-module/db/esb.mv.db`.
+> [!WARNING]
+> If the property `h2.db.migration.module.persistence.database.path` has not been defined in the properties of the module, an exception will be thrown
+> by the Ikasan Shell.
+
 #### Sample Usage
 Command
 

--- a/ikasaneip/cli/shell/jar/src/main/java/org/ikasan/cli/shell/operation/DefaultOperationImpl.java
+++ b/ikasaneip/cli/shell/jar/src/main/java/org/ikasan/cli/shell/operation/DefaultOperationImpl.java
@@ -184,7 +184,7 @@ public class DefaultOperationImpl implements Operation
                 String[] moduleNameParts = param.split("=");
                 if(moduleNameParts.length == 2)
                 {
-                    return moduleNameParts[1].trim().toLowerCase().equals(name.toLowerCase());
+                    return moduleNameParts[1].trim().toLowerCase().endsWith(name.toLowerCase());
                 }
             }
         }


### PR DESCRIPTION
… the running PID, as well as adding property h2.db.migration.module.persistence.database.path as a required property for the migration utility. h2.db.migration.module.persistence.database.path is a required field and represents the path the default ikasan esb database.