### PR TITLE
Ikasan 2423 scheduler agent windows correct commands processor

### DIFF
--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/broker/JobStartingBroker.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/broker/JobStartingBroker.java
@@ -108,6 +108,8 @@ public class JobStartingBroker implements Broker<EnrichedContextualisedScheduled
             new DetachableProcessBuilder(
                 schedulerPersistenceService,
                 new ProcessBuilder(),
+                // The split of the ExecutionEnvironmentProperties supported the Dashboard sending pipe delimited commands
+                // sadly this is now obsolete but this code is retained for the short term for regression support.
                 StringUtils.split(scheduledProcessEvent.getInternalEventDrivenJob().getExecutionEnvironmentProperties(), "|"),
                 scheduledProcessEvent.generateProcessIdentity()
             );
@@ -183,7 +185,6 @@ public class JobStartingBroker implements Broker<EnrichedContextualisedScheduled
                         }
                     });
             }
-
         } else {
             // Once detached, the location of output/error/firetime MUST come from the serialized process.
             outputLog = new File(detachableProcessBuilder.getInitialResultOutput());

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/resources/application.properties
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/resources/application.properties
@@ -12,7 +12,7 @@ logging.level.org.ikasan=INFO
 # Blue console servlet settings (optional)
 server.error.whitelabel.enabled=false
 
-module.java.command=java -server -Xms512m -Xmx512m -XX:MaxMetaspaceSize=196m -Dspring.jta.logDir=${persistence.dir}/${module.name}-ObjectStore -Dorg.apache.activemq.SERIALIZABLE_PACKAGES=* -Dmodule.name=${module.name} -jar ${lib.dir}/${module.name}-*.jar
+module.java.command=java -server -Xms512m -Xmx512m -XX:MaxMetaspaceSize=196m -Dspring.jta.logDir=${persistence.dir}/${module.name}-ObjectStore -Dorg.apache.activemq.SERIALIZABLE_PACKAGES=* -Dmodule.name=${module.name} --add-opens java.base/sun.nio.fs=ALL-UNNAMED --add-exports java.base/sun.nio.fs=ALL-UNNAMED -jar ${lib.dir}/${module.name}-*.jar
 
 # Web Bindings
 h2.db.port=8082
@@ -50,6 +50,7 @@ datasource.dialect=org.hibernate.dialect.H2Dialect
 datasource.show-sql=false
 datasource.hbm2ddl.auto=none
 datasource.validationQuery=select 1
+h2.db.migration.module.persistence.database.path=${persistence.dir}/${module.name}-db/esb
 
 ## Dashboard data extraction settings
 #ikasan.dashboard.extract.enabled=true

--- a/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/CommandProcessor.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/CommandProcessor.java
@@ -4,15 +4,18 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 
 public enum CommandProcessor {
-    WINDOWS_CMD("cmd.exe", "/c", ".cmd"),
-    WINDOWS_POWSHELL("powershell.exe", "-Command", ".ps1"),
-    UNIX_BASH("/bin/bash", "-c", ".sh"),
-    UNKNOWN("", "", "") ;
+    WINDOWS_CMD("CMD","cmd.exe", "/c", ".cmd"),
+    WINDOWS_POWSHELL("POWERSHELL", "powershell.exe", "-Command", ".ps1"),
+    UNIX_BASH("BASH","/bin/bash", "-c", ".sh"),
+    UNIX_KSH("KSH","/bin/ksh", "-c", ".ksh"),
+    UNKNOWN("", "", "", "") ;
+    private final String title;
     private final String name;
     private final String cliFlags;
     private final String scriptFilePostfix;
 
-    CommandProcessor(String name, String cliFlags, String scriptFilePostfix) {
+    CommandProcessor(String title, String name, String cliFlags, String scriptFilePostfix) {
+        this.title = title;
         this.name = name;
         this.cliFlags = cliFlags;
         this.scriptFilePostfix = scriptFilePostfix;
@@ -26,18 +29,23 @@ public enum CommandProcessor {
     public String getName() { return name; }
 
     public static CommandProcessor getCommandProcessor(String[] executionEnvironmentProperties) {
-        CommandProcessor commandProcessor = CommandProcessor.UNIX_BASH;
-        String executionEnvironmentPropertiesStr = executionEnvironmentProperties == null ? "" : String.join("", executionEnvironmentProperties);
+        CommandProcessor commandProcessor = null;
+        String executionEnvironmentPropertiesStr = executionEnvironmentProperties == null ? "" : String.join("", executionEnvironmentProperties).toUpperCase();
         if (StringUtils.isNotBlank(executionEnvironmentPropertiesStr)) {
-            if (executionEnvironmentPropertiesStr.contains(WINDOWS_POWSHELL.name)) {
-                commandProcessor =  CommandProcessor.WINDOWS_POWSHELL;
-            } else if (executionEnvironmentPropertiesStr.contains(WINDOWS_CMD.name)) {
-                commandProcessor =  CommandProcessor.WINDOWS_CMD;
+            for (CommandProcessor processor : CommandProcessor.values()) {
+                if (executionEnvironmentPropertiesStr.contains(processor.title.toUpperCase())) {
+                    commandProcessor = processor;
+                    break;
+                }
             }
-        } else {
+        }
+
+        if (commandProcessor == null || commandProcessor == CommandProcessor.UNKNOWN) {
             // Guess based on current OS
             if (SystemUtils.OS_NAME.contains("Windows")) {
                 commandProcessor =  CommandProcessor.WINDOWS_CMD;
+            } else {
+                commandProcessor =  CommandProcessor.UNIX_BASH;
             }
         }
         return commandProcessor;

--- a/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/DetachableProcessBuilder.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/DetachableProcessBuilder.java
@@ -104,7 +104,7 @@ public class DetachableProcessBuilder {
         if (detachableProcess.getCommandProcessor().equals(CommandProcessor.WINDOWS_CMD) || detachableProcess.getCommandProcessor().equals(CommandProcessor.WINDOWS_POWSHELL)) {
             String wrapperScriptCommands = getWindowsWrapperCommands(commandScriptPath, processExitStatusFile);
             try {
-                commandScriptPath = schedulerPersistenceService.createCommandWrapperScript(detachableProcess.getIdentity(), detachableProcess.getCommandProcessor().getScriptFilePostfix(), wrapperScriptCommands);
+                commandScriptPath = schedulerPersistenceService.createCommandWrapperScript(detachableProcess.getIdentity(), CommandProcessor.WINDOWS_POWSHELL.getScriptFilePostfix(), wrapperScriptCommands);
             } catch (IOException e) {
                 throw new EndpointException(e);
             }
@@ -136,7 +136,7 @@ public class DetachableProcessBuilder {
         isInitialised("Attempt to set command " + commandLineScriptName);
         List<String> commands = new ArrayList<>();
         if (detachableProcess.getCommandProcessor().equals(CommandProcessor.WINDOWS_CMD) || detachableProcess.getCommandProcessor().equals(CommandProcessor.WINDOWS_POWSHELL)) {
-            commands.addAll(Arrays.asList(detachableProcess.getCommandProcessor().getCommandArgs()));
+            commands.addAll(Arrays.asList(CommandProcessor.WINDOWS_POWSHELL.getCommandArgs()));
             commands.add("Start-Process -FilePath Powershell -WindowStyle Hidden -RedirectStandardError \"" + getInitialErrorOutput() + "\" -RedirectStandardOutput \"" + getInitialResultOutput() + "\" -PassThru -ArgumentList \"/c\", " +
                 "\"" + commandLineScriptName + "\"");
         } else {

--- a/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/DetachableProcessBuilder.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/DetachableProcessBuilder.java
@@ -16,11 +16,9 @@ import java.util.*;
  * Its aim is to start the Command Execution Job on the target OS, if the invoker
  * crashed, the process would still continue and leave its error/output/return status in such a way that
  * the invoker could determine success/failure when the invoker was restarted.
- *
  * This is achieved by taking the commands that would have been directly executed by processBuilder, bundling them
  * up in a script, then executing the script and redirecting the return value to file system file, so that it is
  * persisted.
- *
  * It currently supports the command processors on Unix and Windows hosts.
  */
 public class DetachableProcessBuilder {
@@ -100,7 +98,7 @@ public class DetachableProcessBuilder {
         }
         String processExitStatusFile = schedulerPersistenceService.getResultAbsoluteFilePath(detachableProcess.getIdentity());
 
-        // For Windows, we need to wrap the command in another powershelll script because start-process doesn't support script blocks.
+        // For Windows, we need to wrap the command in another Powershell script because start-process doesn't support script blocks.
         if (detachableProcess.getCommandProcessor().equals(CommandProcessor.WINDOWS_CMD) || detachableProcess.getCommandProcessor().equals(CommandProcessor.WINDOWS_POWSHELL)) {
             String wrapperScriptCommands = getWindowsWrapperCommands(commandScriptPath, processExitStatusFile);
             try {

--- a/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/dao/ProcessStatusDaoFSImp.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/dao/ProcessStatusDaoFSImp.java
@@ -9,7 +9,6 @@ import java.io.PrintWriter;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  *
@@ -111,9 +110,9 @@ public class ProcessStatusDaoFSImp implements ProcessStatusDao {
      */
     public void removeScriptAndResult(String processIdentity) throws IOException {
         Files.list(Path.of(this.persistenceDir))
-            .filter(p -> p.toString().contains(getScriptFilePath(processIdentity))
-                ||  p.toString().contains(getWrapperScriptFilePath(processIdentity))
-                ||  p.toString().contains(getResultFilePath(processIdentity)))
+            .filter(p -> p.toString().contains(getScriptFile(processIdentity))
+                ||  p.toString().contains(getWrapperScriptFile(processIdentity))
+                ||  p.toString().contains(getResultFile(processIdentity)))
             .forEach((p) -> {
             try {
                 Files.deleteIfExists(p);
@@ -125,8 +124,12 @@ public class ProcessStatusDaoFSImp implements ProcessStatusDao {
     }
 
 
-    private String getResultFilePath(String processIdentity) {
+    private String getResultFile(String processIdentity) {
         return processIdentity + RESULTS_FILE_POSTFIX;
+    }
+
+    private String getResultFilePath(String processIdentity) {
+        return persistenceDir + FileSystems.getDefault().getSeparator() + getResultFile(processIdentity);
     }
 
     public String getResultAbsoluteFilePath(String processIdentity) {
@@ -135,16 +138,16 @@ public class ProcessStatusDaoFSImp implements ProcessStatusDao {
         return file.getAbsolutePath();
     }
 
-    public String getScriptFilePath(String processIdentity)  {
+    public String getScriptFile(String processIdentity)  {
         return processIdentity + SCRIPT_FILE_POSTFIX;
     }
 
     @Override
-    public String getScriptFilePath(String processIdentity, String scriptPostfix)  {
-        return persistenceDir + FileSystems.getDefault().getSeparator() + processIdentity + SCRIPT_FILE_POSTFIX + scriptPostfix;
+    public String getScriptFilePath(String processIdentity, String fileExtension)  {
+        return persistenceDir + FileSystems.getDefault().getSeparator() + processIdentity + SCRIPT_FILE_POSTFIX + fileExtension;
     }
 
-    public String getWrapperScriptFilePath(String processIdentity)  {
+    public String getWrapperScriptFile(String processIdentity)  {
         return processIdentity + SCRIPT_FILE_POSTFIX + WRAPPER_FILE_POSTFIX;
     }
 }

--- a/ikasaneip/ootb/service/scheduled-process-service/src/test/java/org/ikasan/ootb/scheduled/processtracker/CommandProcessorTest.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/test/java/org/ikasan/ootb/scheduled/processtracker/CommandProcessorTest.java
@@ -1,0 +1,33 @@
+package org.ikasan.ootb.scheduled.processtracker;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommandProcessorTest {
+    @Test
+    void succesfully_identifies_correct_command_processor() {
+        String[] commands = new String[] { "KSH" };
+        CommandProcessor actual = CommandProcessor.getCommandProcessor(commands);
+        assertThat(actual.toString()).isEqualTo(CommandProcessor.UNIX_KSH.toString());
+
+        String[] commandsLower = new String[] { "ksh" };
+        actual = CommandProcessor.getCommandProcessor(commandsLower);
+        assertThat(actual.toString()).isEqualTo(CommandProcessor.UNIX_KSH.toString());
+
+    }
+
+    @Test
+    void attempts_to_guesss_command_processor_when_no_details_passed() {
+        String[] empty = new String[] { };
+
+        CommandProcessor actual = CommandProcessor.getCommandProcessor(null);
+        assertNotNull(actual.toString());
+        assertNotEquals(actual.toString(), CommandProcessor.UNKNOWN.toString());
+
+        actual = CommandProcessor.getCommandProcessor(empty);
+        assertNotNull(actual.toString());
+        assertNotEquals(actual.toString(), CommandProcessor.UNKNOWN.toString());
+    }
+}

--- a/ikasaneip/ootb/service/scheduled-process-service/src/test/java/org/ikasan/ootb/scheduled/processtracker/DetachableProcessBuilderTest.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/test/java/org/ikasan/ootb/scheduled/processtracker/DetachableProcessBuilderTest.java
@@ -134,7 +134,9 @@ public class DetachableProcessBuilderTest {
         assertThat(commands.get(1)).isEqualTo(cp.getCommandArgs()[1]);
 
         assertThat(commands.get(2)).isEqualTo(
-            "Start-Process -FilePath Powershell -WindowStyle Hidden -RedirectStandardError \"errorfile\" -RedirectStandardOutput \"resultfile\" -PassThru -ArgumentList \"/c\", \"null\"");
+            "$errorLogPath = 'errorfile' \r\n" +
+            "$initialResultsPath = 'resultfile' \r\n" +
+            "Start-Process -FilePath Powershell -WindowStyle Hidden -RedirectStandardError $errorLogPath -RedirectStandardOutput $initialResultsPath -PassThru -ArgumentList \"/c\", \"null\"");
     }
 
     @Test


### PR DESCRIPTION
Forces Windows CMD and POWERSHELL command execution jobs to be wrapped by Powershell
Some comments on the intention of the code
Add support for KSH (Korn shell)
Fixed issue with spaced in job names causing issues on Windows when executing command execution jobs
Fixed issue with results files not being saved in the PID directory.

Tested on Windows (CMD/Powershell) and Unix (KSH/BASH)