### PR TITLE
Feature/ikasan 2452 update h2 backup for port binding issue

### DIFF
--- a/ikasaneip/platform/ikasan-h2-backup/readme.md
+++ b/ikasaneip/platform/ikasan-h2-backup/readme.md
@@ -30,8 +30,8 @@ There is also the feature that takes a backup of the database when the module is
 | eai.h2.backup.cron.expression               | The Quartz cron schedule on which the backups are taken for the EAI DB                 | 37 0/5 * * * ? |
 | eai.h2.backup.on.module.shutdown            | Flag to configure if an EAI database backup should be taken when the module shuts down | true           |
 | h2.db.port                                  | The DB port H2 is running on for the module                                            |                |
-| default.h2.port.number.step                 | The amount to increment the port number when testing the default module db             | 1000           |
-| eai.h2.port.number.step                     | The amount to increment the port number when testing the EAI module db                 | 1000           |
+| default.h2.port.number.step (Deprecated)    | The amount to increment the port number when testing the default module db             | 1000           |
+| eai.h2.port.number.step (Deprecated)        | The amount to increment the port number when testing the EAI module db                 | 1000           |
 
 If other H2 databases are used by a module, developers can add a configuration to their module to support H2 database 
 backups using the pattern provided in [IkasanBackupAutoConfiguration.java](./src/main/java/org/ikasan/backup/IkasanBackupAutoConfiguration.java).

--- a/ikasaneip/platform/ikasan-h2-backup/src/main/java/org/ikasan/backup/h2/IkasanBackupAutoConfiguration.java
+++ b/ikasaneip/platform/ikasan-h2-backup/src/main/java/org/ikasan/backup/h2/IkasanBackupAutoConfiguration.java
@@ -49,6 +49,7 @@ public class IkasanBackupAutoConfiguration {
     @Value("${h2.db.port}")
     private int defaultH2PortNumber;
 
+    @Deprecated
     @Value("${default.h2.port.number.step:1000}")
     private int defaultH2PortNumberStep;
 
@@ -73,6 +74,7 @@ public class IkasanBackupAutoConfiguration {
     @Value("${h2.db.port}")
     private int eaiH2PortNumber;
 
+    @Deprecated
     @Value("${eai.h2.port.number.step:1000}")
     private int eaiH2PortNumberStep;
 
@@ -104,7 +106,7 @@ public class IkasanBackupAutoConfiguration {
         h2DatabaseBackupDetails.setNumOfBackupsToRetain(this.defaultIkasanDatabaseBackupNumToRetain);
         h2DatabaseBackupDetails.setDbBackupBaseDirectory(this.persistenceDir + FileSystems.getDefault().getSeparator() + "ESB");
         h2DatabaseBackupDetails.setDbBackupCronSchedule(this.defaultIkasanDatabaseBackupCronExpression);
-        h2DatabaseBackupDetails.setTestH2Port(this.defaultH2PortNumber + this.defaultH2PortNumberStep);
+        h2DatabaseBackupDetails.setTestH2Port(this.defaultH2PortNumber);
         return h2DatabaseBackupDetails;
     }
 
@@ -202,7 +204,7 @@ public class IkasanBackupAutoConfiguration {
         h2DatabaseBackupDetails.setNumOfBackupsToRetain(this.eaiIkasanDatabaseBackupNumToRetain);
         h2DatabaseBackupDetails.setDbBackupBaseDirectory(this.persistenceDir + FileSystems.getDefault().getSeparator() + "EAI");
         h2DatabaseBackupDetails.setDbBackupCronSchedule(this.eaiIkasanDatabaseBackupCronExpression);
-        h2DatabaseBackupDetails.setTestH2Port(this.eaiH2PortNumber + this.eaiH2PortNumberStep);
+        h2DatabaseBackupDetails.setTestH2Port(this.eaiH2PortNumber);
         return h2DatabaseBackupDetails;
     }
 

--- a/ikasaneip/platform/ikasan-h2-backup/src/main/java/org/ikasan/backup/h2/service/H2DatabaseValidator.java
+++ b/ikasaneip/platform/ikasan-h2-backup/src/main/java/org/ikasan/backup/h2/service/H2DatabaseValidator.java
@@ -1,6 +1,5 @@
 package org.ikasan.backup.h2.service;
 
-import org.h2.tools.Server;
 import org.ikasan.backup.h2.exception.H2DatabaseValidationException;
 import org.ikasan.backup.h2.exception.InvalidH2ConnectionUrlException;
 import org.ikasan.backup.h2.model.H2DatabaseBackup;
@@ -47,11 +46,8 @@ public class H2DatabaseValidator {
         String testDbFilePath = this.h2DatabaseBackup.getDbBackupBaseDirectory() + FileSystems.getDefault().getSeparator()
                 + TEST_DIRECTORY;
         String testDbUrl = this.getTestDbUrl(h2DatabaseBackup.getDbUrl(), Integer.toString(portNumber), testDbFilePath);
-        Server server = Server.createTcpServer("-tcpPort", Integer.toString(portNumber), "-tcpAllowOthers");
         this.unzipBackedUpDatabaseFile(backupFileName);
-        server.start();
         this.testDb(testDbUrl, h2DatabaseBackup);
-        server.stop();
         this.cleanTestDirectory();
     }
 

--- a/ikasaneip/platform/ikasan-h2-backup/src/test/java/org/ikasan/backup/h2/service/H2BackupServiceImplTest.java
+++ b/ikasaneip/platform/ikasan-h2-backup/src/test/java/org/ikasan/backup/h2/service/H2BackupServiceImplTest.java
@@ -103,7 +103,7 @@ public class H2BackupServiceImplTest {
         h2DatabaseBackup.setPassword("sa");
         h2DatabaseBackup.setNumOfBackupsToRetain(3);
         h2DatabaseBackup.setDbBackupBaseDirectory(DATABASE_DIRECTORY);
-        h2DatabaseBackup.setTestH2Port(port+1000);
+        h2DatabaseBackup.setTestH2Port(port);
 
         H2BackupServiceImpl h2BackupService = new H2BackupServiceImpl(h2DatabaseBackup
                 , module, false, 5, 5

--- a/ikasaneip/platform/ikasan-h2-backup/src/test/java/org/ikasan/backup/h2/service/H2DatabaseValidatorTest.java
+++ b/ikasaneip/platform/ikasan-h2-backup/src/test/java/org/ikasan/backup/h2/service/H2DatabaseValidatorTest.java
@@ -28,19 +28,23 @@ public class H2DatabaseValidatorTest {
 
     private static final String DATABASE_DIRECTORY = Paths.get("./target","database-dir").toString();
     private static final String CORRUPT_DATABASE_DIRECTORY = Paths.get("./target","corrupt-database-dir").toString();
-
+    private Server server;
     int port = TestSocketUtils.findAvailableTcpPort();
 
     @Before
     public void setup() throws IOException, SQLException {
         H2BackupUtils.unzipFile("./src/test/resources/data/esb-backup-20240321-06-11-00.zip", DATABASE_DIRECTORY);
         H2BackupUtils.unzipFile("./src/test/resources/data/corrupt-db.zip", CORRUPT_DATABASE_DIRECTORY);
+
+        server = Server.createTcpServer("-tcpPort", Integer.toString(port), "-tcpAllowOthers", "-ifNotExists");
+        server.start();
     }
 
     @After
     public void teardown() throws IOException {
         H2BackupUtils.cleanDirectory(Paths.get("./target","database-dir").toString());
         H2BackupUtils.cleanDirectory(Paths.get("./target","corrupt-database-dir").toString());
+        server.stop();
     }
 
 
@@ -55,7 +59,7 @@ public class H2DatabaseValidatorTest {
         h2DatabaseBackup.setDbBackupBaseDirectory(DATABASE_DIRECTORY);
 
         H2DatabaseValidator h2BackupService = new H2DatabaseValidator(h2DatabaseBackup);
-        h2BackupService.runDatabaseValidationTest("./src/test/resources/data/corrupt-db.zip", TestSocketUtils.findAvailableTcpPort());
+        h2BackupService.runDatabaseValidationTest("./src/test/resources/data/corrupt-db.zip", port);
     }
 
     @Test
@@ -71,7 +75,7 @@ public class H2DatabaseValidatorTest {
         H2DatabaseValidator h2BackupService = new H2DatabaseValidator(h2DatabaseBackup);
 
         try {
-            h2BackupService.runDatabaseValidationTest("./src/test/resources/data/esb-backup-20240321-06-11-00.zip", TestSocketUtils.findAvailableTcpPort());
+            h2BackupService.runDatabaseValidationTest("./src/test/resources/data/esb-backup-20240321-06-11-00.zip", port);
         }
         catch (Exception e) {
             fail(String.format("No exception should be thrown here! However the following exception occurred [%s]", e.getMessage()));

--- a/ikasaneip/platform/ikasan-h2-backup/src/test/java/org/ikasan/backup/h2/service/H2DatabaseValidatorTest.java
+++ b/ikasaneip/platform/ikasan-h2-backup/src/test/java/org/ikasan/backup/h2/service/H2DatabaseValidatorTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.util.TestSocketUtils;
+import org.h2.tools.Server;
 
 import java.io.IOException;
 import java.nio.file.Paths;


### PR DESCRIPTION
In the h2 backup implementation, a new H2 instance was being created for verification purposes. We have experienced port clashes with that implementation.  In order to make the implementation more lean, we want to remove the need for spinning new h2 process.