### PR TITLE
IES-471 Add support for Spring Retry as workaround for Windows file s…

### DIFF
--- a/ikasaneip/ootb/module/scheduler-agent/jar/pom.xml
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/pom.xml
@@ -92,16 +92,6 @@
             <groupId>org.ikasan</groupId>
             <artifactId>ikasan-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.junit.jupiter</groupId>
-                    <artifactId>junit-jupiter</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/test/java/org/ikasan/ootb/scheduler/agent/module/component/broker/JobMonitoringBrokerTest.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/test/java/org/ikasan/ootb/scheduler/agent/module/component/broker/JobMonitoringBrokerTest.java
@@ -433,7 +433,7 @@ public class JobMonitoringBrokerTest {
     private void invokeJobStarting(EnrichedContextualisedScheduledProcessEvent enrichedContextualisedScheduledProcessEvent) {
         JobStartingBroker jobStartingBroker = new JobStartingBroker(new SchedulerDefaultPersistenceServiceImpl(
             new SchedulerKryoProcessPersistenceImpl(tmpFolder.getRoot().getAbsolutePath()),
-            new ProcessStatusDaoFSImp(tmpFolder.getRoot().getAbsolutePath())));
+            new ProcessStatusDaoFSImp(tmpFolder.getRoot().getAbsolutePath(), 1, 1)));
         jobStartingBroker.setConfiguration(JobStartingBrokerTest.getTestConfiguration());
         jobStartingBroker.setConfiguredResourceId("test");
         jobStartingBroker.invoke(enrichedContextualisedScheduledProcessEvent);

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/test/java/org/ikasan/ootb/scheduler/agent/module/component/broker/JobStartingBrokerTest.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/test/java/org/ikasan/ootb/scheduler/agent/module/component/broker/JobStartingBrokerTest.java
@@ -90,7 +90,7 @@ public class JobStartingBrokerTest {
         jobStartingBroker = new JobStartingBroker(
             new SchedulerDefaultPersistenceServiceImpl(
                 new SchedulerKryoProcessPersistenceImpl(tmpFolder.getRoot().getAbsolutePath()),
-                new ProcessStatusDaoFSImp(tmpFolder.getRoot().getAbsolutePath())));
+                new ProcessStatusDaoFSImp(tmpFolder.getRoot().getAbsolutePath(), 1, 1)));
         jobStartingBroker.setConfiguration(getTestConfiguration());
         jobStartingBroker.setConfiguredResourceId("test");
     }

--- a/ikasaneip/ootb/service/dry-run-service/pom.xml
+++ b/ikasaneip/ootb/service/dry-run-service/pom.xml
@@ -77,16 +77,6 @@
         <dependency>
             <groupId>org.ikasan</groupId>
             <artifactId>ikasan-test</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.junit.jupiter</groupId>
-                    <artifactId>junit-jupiter</artifactId>
-                </exclusion>
-            </exclusions>
             <scope>test</scope>
         </dependency>
 

--- a/ikasaneip/ootb/service/scheduled-process-service/pom.xml
+++ b/ikasaneip/ootb/service/scheduled-process-service/pom.xml
@@ -75,25 +75,15 @@
         </dependency>
 
         <dependency>
-            <groupId>org.ikasan</groupId>
-            <artifactId>ikasan-test</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.junit.jupiter</groupId>
-                    <artifactId>junit-jupiter</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>test</scope>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+            <version>1.3.4</version>
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-orm</artifactId>
-            <scope>provided</scope>
+            <groupId>org.ikasan</groupId>
+            <artifactId>ikasan-test</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/ScheduledServiceAutoConfiguration.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/ScheduledServiceAutoConfiguration.java
@@ -50,12 +50,18 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 
 /**
- * Scheduler service related configuration required by the scheduler ootb module.
+ * Scheduler service related configuration required by the scheduler ootb module.ó
  */
 public class ScheduledServiceAutoConfiguration {
 
     @Value("${scheduled.process.pid.directory:#{'.' + T(java.nio.file.FileSystems).getDefault().getSeparator() + 'pid'}}")
     String defaultPidDirectory;
+
+    @Value("${scheduled.process.getStatus.max.retries:20}")
+    int maxGetStatusRetries;
+
+    @Value("${scheduled.process.getStatus.retry.delay.millis:3000}")
+    long retryInterval;
 
     @Bean
     SchedulerPersistenceService schedulerPersistenceService(SchedulerProcessPersistenceDao schedulerProcessPersistenceDao,
@@ -70,6 +76,7 @@ public class ScheduledServiceAutoConfiguration {
 
     @Bean
     ProcessStatusDao processStatusDao() {
-        return new ProcessStatusDaoFSImp(defaultPidDirectory);
+        return new ProcessStatusDaoFSImp(defaultPidDirectory, maxGetStatusRetries, retryInterval);
     }
+
 }

--- a/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/ScheduledServiceAutoConfiguration.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/ScheduledServiceAutoConfiguration.java
@@ -50,7 +50,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 
 /**
- * Scheduler service related configuration required by the scheduler ootb module.ó
+ * Scheduler service related configuration required by the scheduler ootb module.
  */
 public class ScheduledServiceAutoConfiguration {
 

--- a/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/dao/ProcessStatusDaoFSImp.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/dao/ProcessStatusDaoFSImp.java
@@ -113,7 +113,7 @@ public class ProcessStatusDaoFSImp implements ProcessStatusDao {
                 Object[] trace = Arrays.stream(e.getStackTrace()).toArray();
                 returnCodeString += ", content was [" + fileContent + "] ,issue [" + e.getMessage() + ", " + e.getClass().getSimpleName()+ ", " + (trace.length > 0 ? trace[0] : "") + "]";
             }
-            LOGGER.warn(returnCodeString);
+            LOGGER.info(returnCodeString);
         }
         return returnCodeString;
     }

--- a/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/dao/ProcessStatusDaoFSImp.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/dao/ProcessStatusDaoFSImp.java
@@ -2,34 +2,41 @@ package org.ikasan.ootb.scheduled.processtracker.dao;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.support.RetrySynchronizationManager;
+import org.springframework.retry.support.RetryTemplate;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.Arrays;
 
-/**
- *
- */
 public class ProcessStatusDaoFSImp implements ProcessStatusDao {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProcessStatusDaoFSImp.class);
     protected static final String RESULTS_FILE_POSTFIX = "_results";
     protected static final String SCRIPT_FILE_POSTFIX = "_script";
     protected static final String WRAPPER_FILE_POSTFIX = "_wrapper";
-    /** persistence directory */
-    String persistenceDir;
-
-    File persistenceDirFile;
+    private String persistenceDir;
+    private int maxGetStatusRetries;
+    private long retryInterval;
+    private File persistenceDirFile;
+    private RetryTemplate retryTemplate;
 
     /**
      * Constructor
      * @param persistenceDir to be created
      */
-    public ProcessStatusDaoFSImp(String persistenceDir)
+    public ProcessStatusDaoFSImp(String persistenceDir,
+                                 int maxGetStatusRetries,
+                                 long retryInterval)
     {
         this.persistenceDir = persistenceDir;
+        this.maxGetStatusRetries = maxGetStatusRetries;
+        this.retryInterval = retryInterval;
         if(persistenceDir == null)
         {
             throw new IllegalArgumentException("persistence directory cannot be 'null");
@@ -41,6 +48,11 @@ public class ProcessStatusDaoFSImp implements ProcessStatusDao {
             if (!persistenceDirFile.mkdirs())
                 LOGGER.warn("Attempt to create persistence directory " + persistenceDir + " failed when we would not expect it to, this may case further issues");
         }
+        retryTemplate = RetryTemplate.builder()
+            .maxAttempts(maxGetStatusRetries)
+            .fixedBackoff(retryInterval)
+            .retryOn(NoSuchFileException.class)
+            .build();
     }
 
     /**
@@ -85,21 +97,41 @@ public class ProcessStatusDaoFSImp implements ProcessStatusDao {
         String returnCodeString ;
         String returnResultsPath = getResultAbsoluteFilePath(processIdentity);
         String fileContent = null;
-        Path filePath = Path.of(returnResultsPath);
         try {
-            fileContent = Files.readString(filePath).trim();
-            // On Windows we have to force utf-8 output, MS inserts a Byte Order Mark for UTF8 files :(
+            fileContent = retryTemplate.execute(ctx -> getPersistedReturnCodeData(Path.of(returnResultsPath)));
+            // On Windows we have to force utf-8 output, MS inserts a Byte Order Mark for UTF8 files
             fileContent = fileContent.replace("\uFEFF", "");
             int numericValue = Integer.parseInt(fileContent);
             returnCodeString = Integer.toString(numericValue);
         } catch (IOException | NumberFormatException e) {
-            String message = "Attempt to read the status from file [" + returnResultsPath +
-                "] failed, content was [" + fileContent +
-                "] ,issue [" + e.getMessage() + "]";
-            LOGGER.warn(message, e);
-            returnCodeString = message + " see agent logs for " + e.getClass().getSimpleName();
+            returnCodeString = "Attempts to read the status from file [" + returnResultsPath +
+                "] failed";
+            if (e instanceof NoSuchFileException) {
+                returnCodeString += " after " + maxGetStatusRetries + " retries and an interval of " + retryInterval +
+                    " milliseconds, this is a known operating system issue, consider increasing these values";
+            } else {
+                Object[] trace = Arrays.stream(e.getStackTrace()).toArray();
+                returnCodeString += ", content was [" + fileContent + "] ,issue [" + e.getMessage() + ", " + e.getClass().getSimpleName()+ ", " + (trace.length > 0 ? trace[0] : "") + "]";
+            }
+            LOGGER.warn(returnCodeString);
         }
         return returnCodeString;
+    }
+
+    /**
+     * Attempt to get the content of file containing the return results using a spring retry approach
+     * It has been proven on Windows, for parallel optations, that the OS does not make the
+     * file available until several seconds after the process that created it has finished.
+     * @param fileResultsPath the expected location of the results
+     * @return the contents of the results file.
+     */
+    private String getPersistedReturnCodeData(Path fileResultsPath) throws IOException {
+        RetryContext retryContext = RetrySynchronizationManager.getContext();
+        if (retryContext.getRetryCount() > 1) {
+            LOGGER.warn("Attempting to get persisted return code from path " +
+                fileResultsPath + "Retry Number: " + retryContext.getRetryCount() + ", interval " + retryInterval);
+        }
+        return Files.readString(fileResultsPath).trim();
     }
 
     /*

--- a/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/dao/ProcessStatusDaoFSImp.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/processtracker/dao/ProcessStatusDaoFSImp.java
@@ -46,7 +46,7 @@ public class ProcessStatusDaoFSImp implements ProcessStatusDao {
         if(!persistenceDirFile.exists())
         {
             if (!persistenceDirFile.mkdirs())
-                LOGGER.warn("Attempt to create persistence directory " + persistenceDir + " failed when we would not expect it to, this may case further issues");
+                LOGGER.info("Attempt to create persistence directory " + persistenceDir + " failed when we would not expect it to, this may case further issues");
         }
         retryTemplate = RetryTemplate.builder()
             .maxAttempts(maxGetStatusRetries)
@@ -109,11 +109,11 @@ public class ProcessStatusDaoFSImp implements ProcessStatusDao {
             if (e instanceof NoSuchFileException) {
                 returnCodeString += " after " + maxGetStatusRetries + " retries and an interval of " + retryInterval +
                     " milliseconds, this is a known operating system issue, consider increasing these values";
+                LOGGER.info(returnCodeString);
             } else {
-                Object[] trace = Arrays.stream(e.getStackTrace()).toArray();
-                returnCodeString += ", content was [" + fileContent + "] ,issue [" + e.getMessage() + ", " + e.getClass().getSimpleName()+ ", " + (trace.length > 0 ? trace[0] : "") + "]";
+                returnCodeString += ", content was [" + fileContent + "] ,issue [" + e.getMessage() + ", " + e.getClass().getSimpleName()+ "]";
+                LOGGER.error(returnCodeString, e);
             }
-            LOGGER.info(returnCodeString);
         }
         return returnCodeString;
     }
@@ -128,7 +128,7 @@ public class ProcessStatusDaoFSImp implements ProcessStatusDao {
     private String getPersistedReturnCodeData(Path fileResultsPath) throws IOException {
         RetryContext retryContext = RetrySynchronizationManager.getContext();
         if (retryContext.getRetryCount() > 1) {
-            LOGGER.warn("Attempting to get persisted return code from path " +
+            LOGGER.info("Attempting to get persisted return code from path " +
                 fileResultsPath + "Retry Number: " + retryContext.getRetryCount() + ", interval " + retryInterval);
         }
         return Files.readString(fileResultsPath).trim();

--- a/ikasaneip/ootb/service/scheduled-process-service/src/test/java/org/ikasan/ootb/scheduled/processtracker/dao/ProcessStatusDaoFSImpTest.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/test/java/org/ikasan/ootb/scheduled/processtracker/dao/ProcessStatusDaoFSImpTest.java
@@ -27,7 +27,7 @@ public class ProcessStatusDaoFSImpTest {
 
     @BeforeEach
     void setUp() {
-        processStatusDao = new ProcessStatusDaoFSImp(tempDir.toString());
+        processStatusDao = new ProcessStatusDaoFSImp(tempDir.toString(), 2, 1l);
     }
 
     @Test
@@ -80,6 +80,17 @@ public class ProcessStatusDaoFSImpTest {
     }
 
     @Test
+    void when_the_result_is_missing_hint_that_retry_and_timeout_need_adjusting() throws IOException {
+        String resultsFile = processStatusDao.getResultAbsoluteFilePath(IDENTITY);
+        removeFile(resultsFile);
+
+        String acutalReturnValue = processStatusDao.getPersistedReturnCode(IDENTITY);
+
+        assertThat(acutalReturnValue).contains("Attempts to read the status from file");
+        assertThat(acutalReturnValue).contains(" failed after 2 retries and an interval of 1 milliseconds, this is a known operating system issue, consider increasing these values");
+    }
+
+    @Test
     void ensure_the_tidy_up_removes_all_files() throws IOException {
         CommandProcessor cp = CommandProcessor.getCommandProcessor(null);
         String resultsFilePath = processStatusDao.getResultAbsoluteFilePath(IDENTITY);
@@ -105,6 +116,10 @@ public class ProcessStatusDaoFSImpTest {
         try (PrintWriter out = new PrintWriter(file)) {
             out.println(value);
         }
+    }
+    private void removeFile(String resultsFile) throws FileNotFoundException {
+        File file = new File(resultsFile);
+        file.delete();
     }
 
 }


### PR DESCRIPTION
On Windows, the file written to by the command execution job, that contains the exist status of the execution, is not released by the OS for general consumption (possibly due to virus scanner) for up to 60 seconds after it was created. The Spring-Retry mechanism will try 20 times, with 3 seconds gaps, to read the status file before giving up with an appropriate error. 