### PR TITLE
IKASAN-2474 Add flag to allwo error return if 0 exit code but content…

### DIFF
--- a/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/ScheduledServiceAutoConfiguration.java
+++ b/ikasaneip/ootb/service/scheduled-process-service/src/main/java/org/ikasan/ootb/scheduled/ScheduledServiceAutoConfiguration.java
@@ -57,7 +57,7 @@ public class ScheduledServiceAutoConfiguration {
     @Value("${scheduled.process.pid.directory:#{'.' + T(java.nio.file.FileSystems).getDefault().getSeparator() + 'pid'}}")
     String defaultPidDirectory;
 
-    @Value("${scheduled.process.getStatus.max.retries:20}")
+    @Value("${scheduled.process.getStatus.max.retries:60}")
     int maxGetStatusRetries;
 
     @Value("${scheduled.process.getStatus.retry.delay.millis:3000}")


### PR DESCRIPTION
Add support for the job.monitoring.broker.errorlog.considered.error flag. This will cause a fail status and return code of 124816 if the error log is written to AND the command invoked returns a zero error code. If the command invoked does not return a zero error code, this code will be bypassed.

The submission also include a fix to improve the return code reporting for command execution jobs that complete within 5 seconds of starting.

As agreed, this submission also includes in increase to the default value for scheduled.process.getStatus.max.retries, increased as a result of feedback from testing.