### PR TITLE
IKASAN-2475 Add router and dev null endpoint for inactive command exe…

### DIFF
--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/boot/components/JobProcessingFlowComponentFactory.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/boot/components/JobProcessingFlowComponentFactory.java
@@ -95,12 +95,14 @@ import org.ikasan.ootb.scheduler.agent.module.component.broker.configuration.Job
 import org.ikasan.ootb.scheduler.agent.module.component.broker.configuration.JobStartingBrokerConfiguration;
 import org.ikasan.ootb.scheduler.agent.module.component.converter.JobInitiationToContextualisedScheduledProcessEventConverter;
 import org.ikasan.ootb.scheduler.agent.module.component.converter.configuration.JobInitiationToContextualisedScheduledProcessEventConverterConfiguration;
+import org.ikasan.ootb.scheduler.agent.module.component.router.ActiveInstanceRouter;
 import org.ikasan.ootb.scheduler.agent.module.component.serialiser.ScheduledProcessEventToBigQueueMessageSerialiser;
 import org.ikasan.ootb.scheduler.agent.rest.cache.InboundJobQueueCache;
 import org.ikasan.spec.component.endpoint.Broker;
 import org.ikasan.spec.component.endpoint.Consumer;
 import org.ikasan.spec.component.endpoint.Producer;
 import org.ikasan.spec.component.routing.MultiRecipientRouter;
+import org.ikasan.spec.component.routing.SingleRecipientRouter;
 import org.ikasan.spec.component.transformation.Converter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -256,6 +258,14 @@ public class JobProcessingFlowComponentFactory {
         BigQueueProducer bigQueueProducer = new BigQueueProducer<>(this.outboundQueue);
         bigQueueProducer.setSerialiser(serialiser);
         return bigQueueProducer;
+    }
+
+    /**
+     * Get the single recipient router.
+     * @return the ActiveInstanceRouter
+     */
+    public SingleRecipientRouter getJobSRRouter() {
+        return new ActiveInstanceRouter();
     }
 
     /**

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/router/ActiveInstanceRouter.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/router/ActiveInstanceRouter.java
@@ -56,8 +56,8 @@ import org.slf4j.LoggerFactory;
 public class ActiveInstanceRouter implements SingleRecipientRouter<EnrichedContextualisedScheduledProcessEvent>
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ActiveInstanceRouter.class);
-    public static String ACTIVE_INSTANCE_ID = "Active Instance ID";
-    public static String INACTIVE_INSTANCE_ID = "Inactive Instance ID";
+    public static String ACTIVE_INSTANCE_ID = "ACTIVE_INSTANCE_ID";
+    public static String INACTIVE_INSTANCE_ID = "INACTIVE_INSTANCE_ID";
 
     public ActiveInstanceRouter() {
     }

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/router/ActiveInstanceRouter.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/router/ActiveInstanceRouter.java
@@ -1,0 +1,75 @@
+/*
+ * $Id$
+ * $URL$
+ *
+ * ====================================================================
+ * Ikasan Enterprise Integration Platform
+ *
+ * Distributed under the Modified BSD License.
+ * Copyright notice: The copyright for this software and a full listing
+ * of individual contributors are as shown in the packaged copyright.txt
+ * file.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  - Neither the name of the ORGANIZATION nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ */
+package org.ikasan.ootb.scheduler.agent.module.component.router;
+
+import org.ikasan.ootb.scheduler.agent.module.model.EnrichedContextualisedScheduledProcessEvent;
+import org.ikasan.ootb.scheduler.agent.rest.cache.ContextInstanceCache;
+import org.ikasan.spec.component.routing.RouterException;
+import org.ikasan.spec.component.routing.SingleRecipientRouter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Router to determine whether the scheduled process event belongs to an active context instance
+ *
+ * @author Ikasan Development Team
+ *
+ */
+public class ActiveInstanceRouter implements SingleRecipientRouter<EnrichedContextualisedScheduledProcessEvent>
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ActiveInstanceRouter.class);
+    public static String ACTIVE_INSTANCE_ID = "Active Instance ID";
+    public static String INACTIVE_INSTANCE_ID = "Inactive Instance ID";
+
+    public ActiveInstanceRouter() {
+    }
+
+    @Override
+    public String route(EnrichedContextualisedScheduledProcessEvent messageToRoute) throws RouterException
+    {
+        if (ContextInstanceCache.existsInCache(messageToRoute.getContextInstanceId())) {
+            return ACTIVE_INSTANCE_ID;
+        } else {
+            LOGGER.info("The process event does not have an active contextInstanceID [" + messageToRoute.getContextInstanceId() + "], sending to inactive route");
+            return INACTIVE_INSTANCE_ID;
+        }
+    }
+}

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/test/java/org/ikasan/ootb/scheduler/agent/module/component/router/ActiveInstanceRouterTest.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/test/java/org/ikasan/ootb/scheduler/agent/module/component/router/ActiveInstanceRouterTest.java
@@ -1,0 +1,34 @@
+package org.ikasan.ootb.scheduler.agent.module.component.router;
+
+import org.ikasan.job.orchestration.model.context.ContextInstanceImpl;
+import org.ikasan.ootb.scheduler.agent.module.model.EnrichedContextualisedScheduledProcessEvent;
+import org.ikasan.ootb.scheduler.agent.rest.cache.ContextInstanceCache;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ActiveInstanceRouterTest {
+
+    @Test
+    public void test_instance_active_route() {
+        ContextInstanceCache.instance().put("contextInstanceId", new ContextInstanceImpl());
+
+        EnrichedContextualisedScheduledProcessEvent event = new EnrichedContextualisedScheduledProcessEvent();
+        event.setContextInstanceId("contextInstanceId");
+        ActiveInstanceRouter activeInstanceRouter = new ActiveInstanceRouter();
+        String result = activeInstanceRouter.route(event);
+
+        Assert.assertEquals(ActiveInstanceRouter.ACTIVE_INSTANCE_ID, result);
+    }
+
+    @Test
+    public void test_instance_inactive_route() {
+        ContextInstanceCache.instance().removeAll();
+
+        EnrichedContextualisedScheduledProcessEvent event = new EnrichedContextualisedScheduledProcessEvent();
+        event.setContextInstanceId("contextInstanceId");
+        ActiveInstanceRouter activeInstanceRouter = new ActiveInstanceRouter();
+        String result = activeInstanceRouter.route(event);
+
+        Assert.assertEquals(ActiveInstanceRouter.INACTIVE_INSTANCE_ID, result);
+    }
+}


### PR DESCRIPTION
Add router and dev null endpoint for inactive command execution jobs.

Note: this solution requires an active job plan to read off and discard the expired command executions from the job queue.