### PR TITLE
IKASAN-2487 - Add Content-Security-Policy to Webconsole headers

### DIFF
--- a/ikasaneip/webconsole/jar/src/main/java/org/ikasan/web/WebSecurityConfig.java
+++ b/ikasaneip/webconsole/jar/src/main/java/org/ikasan/web/WebSecurityConfig.java
@@ -100,6 +100,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter
             .logout().logoutSuccessUrl("/").logoutUrl("/j_spring_security_logout").deleteCookies("JSESSIONID")
             .and()
             .csrf().disable()
-            .headers().frameOptions().sameOrigin();
+            .headers()
+                .contentSecurityPolicy("script-src 'self'")
+                .and()
+                .frameOptions().sameOrigin();
     }
 }


### PR DESCRIPTION
This PR relates to a minor security vulnerability raised by a team in Japan. It should at the mitigate any cross-site scripting possibilities.