### PR TITLE
IKASAN-2487 - Add Content-Security-Policy to Webconsole headers

### DIFF
--- a/ikasaneip/webconsole/jar/src/main/java/org/ikasan/web/WebSecurityConfig.java
+++ b/ikasaneip/webconsole/jar/src/main/java/org/ikasan/web/WebSecurityConfig.java
@@ -56,8 +56,11 @@ public class WebSecurityConfig {
             .csrf(httpSecurityCsrfConfigurer
                 -> httpSecurityCsrfConfigurer.disable())
             .headers(httpSecurityHeadersConfigurer
-                -> httpSecurityHeadersConfigurer.frameOptions(frameOptionsConfig
-                    -> frameOptionsConfig.sameOrigin()));
+                -> {httpSecurityHeadersConfigurer.frameOptions(frameOptionsConfig
+                    -> frameOptionsConfig.sameOrigin());
+                    httpSecurityHeadersConfigurer.contentSecurityPolicy(contentSecurityPolicy
+                    -> contentSecurityPolicy.policyDirectives("script-src 'self'"));
+            });
 
         return http.build();
     }


### PR DESCRIPTION
This PR relates to a minor security vulnerability raised by a team in Japan. It should at the mitigate any cross-site scripting possibilities.