### PR TITLE
IKASAN-2669 do not return empty string when parameters are not resolv…

### DIFF
--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/test/java/org/ikasan/ootb/scheduler/agent/QuartzSchedulerFileEventJobFlowTest.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/test/java/org/ikasan/ootb/scheduler/agent/QuartzSchedulerFileEventJobFlowTest.java
@@ -46,11 +46,9 @@ import org.awaitility.Awaitility;
 import org.ikasan.bigqueue.IBigQueue;
 import org.ikasan.job.orchestration.model.context.ContextInstanceImpl;
 import org.ikasan.ootb.scheduled.model.InternalEventDrivenJobInstanceImpl;
-import org.ikasan.ootb.scheduler.agent.module.AgentFlowProfiles;
 import org.ikasan.ootb.scheduler.agent.module.Application;
 import org.ikasan.ootb.scheduler.agent.module.boot.recovery.AgentInstanceRecoveryManager;
 import org.ikasan.ootb.scheduler.agent.module.component.converter.configuration.FileWatcherJobConverterConfiguration;
-import org.ikasan.ootb.scheduler.agent.module.configuration.SchedulerAgentConfiguredModuleConfiguration;
 import org.ikasan.ootb.scheduler.agent.rest.cache.ContextInstanceCache;
 import org.ikasan.ootb.scheduler.agent.rest.cache.InternalFileWatcherJobQueueCache;
 import org.ikasan.ootb.scheduler.agent.rest.dto.ContextParameterInstanceDto;
@@ -59,7 +57,6 @@ import org.ikasan.spec.error.reporting.ErrorOccurrence;
 import org.ikasan.spec.error.reporting.ErrorReportingService;
 import org.ikasan.spec.flow.Flow;
 import org.ikasan.spec.module.Module;
-import org.ikasan.spec.module.ModuleActivator;
 import org.ikasan.spec.scheduled.context.model.ContextParameter;
 import org.ikasan.spec.scheduled.event.model.DryRunParameters;
 import org.ikasan.spec.scheduled.instance.model.ContextInstance;
@@ -69,7 +66,6 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -80,8 +76,6 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
 /**

--- a/ikasaneip/ootb/rest/scheduler-agent-rest-module/src/main/java/org/ikasan/ootb/scheduler/agent/rest/cache/ContextInstanceCache.java
+++ b/ikasaneip/ootb/rest/scheduler-agent-rest-module/src/main/java/org/ikasan/ootb/scheduler/agent/rest/cache/ContextInstanceCache.java
@@ -109,8 +109,14 @@ public class ContextInstanceCache {
      * @return The value of the context parameter matching the correlation ID and parameter name. If not found, returns an empty string.
      */
     public static String getContextParameter(String correlationId, String contextParameterName) {
+        String returnValue;
         if (correlationId != null && contextParameterName != null) {
             ContextInstance instance = ContextInstanceCache.instance().getByCorrelationId(correlationId);
+            if(instance == null) {
+                LOG.info(String.format("Could not find context parameter for job plan instance instance[%s] and parameter name [%s]. " +
+                    "The context instance was not present in the context instance cache!", correlationId, contextParameterName));
+                return "JOB_PLAN_INSTANCE_NOT_FOUND_IN_CACHE";
+            }
             if (instance != null) {
                 List<ContextParameterInstance> contextParameters = instance.getContextParameters();
                 if (contextParameters != null) {
@@ -127,8 +133,8 @@ public class ContextInstanceCache {
 
         // We return an empty String if nothing found!
         LOG.info(String.format("Could not find context parameter for job plan instance instance[%s] and parameter name [%s]. " +
-            "Returning empty String.", correlationId, contextParameterName));
-        return "";
+            "The context parameter was not present in the context instance!", correlationId, contextParameterName));
+        return "CONTEXT_PARAMETER_NOT_FOUND_IN_JOB_PLAN_INSTANCE";
     }
 
     /**

--- a/ikasaneip/ootb/rest/scheduler-agent-rest-module/src/test/java/org/ikasan/ootb/scheduler/agent/rest/cache/ContextInstanceCacheTest.java
+++ b/ikasaneip/ootb/rest/scheduler-agent-rest-module/src/test/java/org/ikasan/ootb/scheduler/agent/rest/cache/ContextInstanceCacheTest.java
@@ -16,25 +16,25 @@ import static org.junit.Assert.*;
 public class ContextInstanceCacheTest {
 
     @Test
-    public void getContextParameter_should_return_empth_string_values() {
-        assertEquals("",ContextInstanceCache.getContextParameter(null, "contextParameterName"));
-        assertEquals("",ContextInstanceCache.getContextParameter("contextInstanceId", null));
+    public void getContextParameter_should_return_relevant_string_values() {
+        assertEquals("CONTEXT_PARAMETER_NOT_FOUND_IN_JOB_PLAN_INSTANCE",ContextInstanceCache.getContextParameter(null, "contextParameterName"));
+        assertEquals("CONTEXT_PARAMETER_NOT_FOUND_IN_JOB_PLAN_INSTANCE",ContextInstanceCache.getContextParameter("contextInstanceId", null));
     }
 
     @Test
-    public void getContextParameter_should_return_empth_string_null_context_instance() {
+    public void getContextParameter_should_return_relevant_string_null_context_instance() {
         String contextInstanceId = RandomStringUtils.randomAlphanumeric(12);
-        assertEquals("",ContextInstanceCache.getContextParameter(contextInstanceId, "contextParameterName"));
+        assertEquals("JOB_PLAN_INSTANCE_NOT_FOUND_IN_CACHE",ContextInstanceCache.getContextParameter(contextInstanceId, "contextParameterName"));
     }
 
     @Test
-    public void getContextParameter_should_return_empty_string_null_context_parameters() {
+    public void getContextParameter_should_return_relevant_string_null_context_parameters() {
         String contextInstanceId = RandomStringUtils.randomAlphanumeric(12);
         ContextInstance instance = new ContextInstanceImpl();
         instance.setId(contextInstanceId);
 
         ContextInstanceCache.instance().put(instance.getId(), instance);
-        assertEquals("", ContextInstanceCache.getContextParameter(contextInstanceId, "contextParameterName"));
+        assertEquals("CONTEXT_PARAMETER_NOT_FOUND_IN_JOB_PLAN_INSTANCE", ContextInstanceCache.getContextParameter(contextInstanceId, "contextParameterName"));
     }
 
     @Test
@@ -54,7 +54,7 @@ public class ContextInstanceCacheTest {
     }
 
     @Test
-    public void getContextParameter_should_return_empty_string_with_context_parameters_null_name() {
+    public void getContextParameter_should_return_relevant_string_with_context_parameters_null_name() {
         String contextInstanceId = RandomStringUtils.randomAlphanumeric(12);
         ContextInstance instance = new ContextInstanceImpl();
         instance.setId(contextInstanceId);
@@ -66,11 +66,11 @@ public class ContextInstanceCacheTest {
         instance.setContextParameters(params);
 
         ContextInstanceCache.instance().put(instance.getId(), instance);
-        assertEquals("", ContextInstanceCache.getContextParameter(contextInstanceId, "BusinessDate"));
+        assertEquals("CONTEXT_PARAMETER_NOT_FOUND_IN_JOB_PLAN_INSTANCE", ContextInstanceCache.getContextParameter(contextInstanceId, "BusinessDate"));
     }
 
     @Test
-    public void getContextParameter_should_return_empty_string_with_context_parameters_null_value() {
+    public void getContextParameter_should_return_relevant_string_with_context_parameters_null_value() {
         String contextInstanceId = RandomStringUtils.randomAlphanumeric(12);
         ContextInstance instance = new ContextInstanceImpl();
         instance.setId(contextInstanceId);
@@ -81,7 +81,7 @@ public class ContextInstanceCacheTest {
         instance.setContextParameters(params);
 
         ContextInstanceCache.instance().put(instance.getId(), instance);
-        assertEquals("",ContextInstanceCache.getContextParameter(contextInstanceId, "BusinessDate"));
+        assertEquals("CONTEXT_PARAMETER_NOT_FOUND_IN_JOB_PLAN_INSTANCE",ContextInstanceCache.getContextParameter(contextInstanceId, "BusinessDate"));
     }
 
     @Test


### PR DESCRIPTION
…ed. This removes the possibility of wildcard matches if the parameter is used to match filenames with a wildcard pattern in them.