### PR TITLE
IKASAN-2707 Spec changes to support distrubuted dashboards, minor fix…

### DIFF
--- a/ikasaneip/cli/shell/jar/src/main/java/org/ikasan/cli/shell/reporting/ProcessInfo.java
+++ b/ikasaneip/cli/shell/jar/src/main/java/org/ikasan/cli/shell/reporting/ProcessInfo.java
@@ -43,8 +43,6 @@ package org.ikasan.cli.shell.reporting;
 import org.ikasan.cli.shell.operation.model.ProcessType;
 import org.json.JSONObject;
 
-import java.util.Optional;
-
 /**
  * ProcessInfo model.
  *
@@ -160,25 +158,30 @@ public class ProcessInfo
     public ProcessInfo setProcess(Process process)
     {
         this.process = process;
-        if(process != null && process.info() != null)
+        if(process != null)
         {
             this.running = process.isAlive();
             this.pid = process.pid();
 
-            if (process.info().command().isPresent())
+            // process.info() re-queries the live OS process table on every call, so it can return a
+            // different snapshot each time - for a short-lived process (e.g. the "kill -9" used to stop
+            // Solr) it can go from present to empty between two calls if the process exits in between.
+            // Take a single snapshot here and reuse it so the isPresent()/get() pairs below stay consistent.
+            ProcessHandle.Info info = process.info();
+
+            if (info.command().isPresent())
             {
-                this.command = process.info().command().get();
+                this.command = info.command().get();
             }
 
-            if (process.info().user().isPresent())
+            if (info.user().isPresent())
             {
-                this.username = process.info().user().get();
+                this.username = info.user().get();
             }
 
-            Optional<String> commandLine = process.info().commandLine();
-            if (commandLine.isPresent())
+            if (info.commandLine().isPresent())
             {
-                this.commandLine = process.info().commandLine().get();
+                this.commandLine = info.commandLine().get();
             }
         }
 

--- a/ikasaneip/rest/rest-module/src/main/java/org/ikasan/rest/module/ModuleControlApplication.java
+++ b/ikasaneip/rest/rest-module/src/main/java/org/ikasan/rest/module/ModuleControlApplication.java
@@ -193,6 +193,9 @@ public class ModuleControlApplication
     /**
      * Retrieves a specific flow within a module based on the provided module name and flow name.
      *
+     * The module is explicitly null-checked before accessing its flows to return a clean 404
+     * rather than leaking a NullPointerException stack trace to the caller (IKASAN-2738).
+     *
      * @param moduleName The name of the module containing the flow.
      * @param flowName The name of the specific flow to retrieve.
      * @return ResponseEntity representing the retrieved FlowDto containing flow information.
@@ -205,6 +208,12 @@ public class ModuleControlApplication
         @PathVariable("flowName") String flowName)
     {
         Module<Flow> module = moduleService.getModule(moduleName);
+        if (module == null)
+        {
+            return new ResponseEntity(new ErrorDto("Module [" + moduleName + "] not found."),
+                HttpStatus.NOT_FOUND);
+        }
+
         Flow flow = module.getFlow(flowName);
         if (flow != null)
             return new ResponseEntity(new FlowDto(flow.getName(), flow.getState()), HttpStatus.OK);

--- a/ikasaneip/rest/rest-module/src/test/java/org/ikasan/rest/module/DownloadLogFileApplicationTest.java
+++ b/ikasaneip/rest/rest-module/src/test/java/org/ikasan/rest/module/DownloadLogFileApplicationTest.java
@@ -158,9 +158,9 @@ public class DownloadLogFileApplicationTest {
             .andExpect(status().is(HttpStatus.INTERNAL_SERVER_ERROR.value()))
             .andReturn();
 
-        Assert.assertTrue(results.getResponse().getContentAsString().endsWith("/ikasan/ikasaneip/rest" +
-            "/rest-module/src/test/resources/data/logs/application.log]. Log file is too big to download. Maximum size " +
-            "allowed is 20 bytes."));
+        Assert.assertEquals("Not able to download the file for [" + fullPathName +
+            "]. Log file is too big to download. Maximum size allowed is 20 bytes.",
+            results.getResponse().getContentAsString());
         Assert.assertEquals(MediaType.APPLICATION_OCTET_STREAM_VALUE, results.getResponse().getContentType());
         Assert.assertEquals("attachment;filename=application.log", results.getResponse().getHeader("Content-Disposition"));
     }
@@ -190,9 +190,9 @@ public class DownloadLogFileApplicationTest {
             .andExpect(status().is(HttpStatus.INTERNAL_SERVER_ERROR.value()))
             .andReturn();
 
-        Assert.assertTrue(results.getResponse().getContentAsString().endsWith("/ikasan/ikasaneip/rest" +
-            "/rest-module/src/test/resources/data/logs/some-random-file.txt]. Log file name must be one of the " +
-            "following[application.log, h2.log, h2-server.log]"));
+        Assert.assertEquals("Not able to download the file for [" + fullPathName +
+            "]. Log file name must be one of the following[application.log, h2.log, h2-server.log]",
+            results.getResponse().getContentAsString());
         Assert.assertEquals(MediaType.APPLICATION_OCTET_STREAM_VALUE, results.getResponse().getContentType());
         Assert.assertEquals("attachment;filename=some-random-file.txt", results.getResponse().getHeader("Content-Disposition"));
     }
@@ -224,9 +224,9 @@ public class DownloadLogFileApplicationTest {
             .andExpect(status().is(HttpStatus.INTERNAL_SERVER_ERROR.value()))
             .andReturn();
 
-        Assert.assertTrue(results.getResponse().getContentAsString().endsWith("/ikasan/ikasaneip/rest/rest-module" +
-            "/src/test/resources/data/logs/application.log.doesNotExist.log]. Log file name must be one of the " +
-            "following[application.log, h2.log, h2-server.log]"));
+        Assert.assertEquals("Not able to download the file for [" + fullPathName +
+            "]. Log file name must be one of the following[application.log, h2.log, h2-server.log]",
+            results.getResponse().getContentAsString());
         Assert.assertEquals(MediaType.APPLICATION_OCTET_STREAM_VALUE, results.getResponse().getContentType());
         Assert.assertEquals("attachment;filename=application.log.doesNotExist.log", results.getResponse().getHeader("Content-Disposition"));
     }

--- a/ikasaneip/rest/rest-module/src/test/java/org/ikasan/rest/module/ModuleControlApplicationTest.java
+++ b/ikasaneip/rest/rest-module/src/test/java/org/ikasan/rest/module/ModuleControlApplicationTest.java
@@ -164,6 +164,26 @@ public class ModuleControlApplicationTest
 
     @Test
     @WithMockUser(authorities = "WebServiceAdmin")
+    public void getFlowStateWhenModuleDoesntExist() throws Exception
+    {
+        Mockito
+            .when(moduleService.getModule("nonExistingModule"))
+            .thenReturn(null);
+        RequestBuilder requestBuilder = MockMvcRequestBuilders.get("/rest/moduleControl/nonExistingModule/test Flow")
+            .accept(MediaType.APPLICATION_JSON_VALUE);
+        MvcResult result = mockMvc.perform(requestBuilder).andReturn();
+        Mockito
+            .verify(moduleService).getModule("nonExistingModule");
+        Mockito.verifyNoMoreInteractions(moduleService);
+        assertEquals(404, result.getResponse().getStatus());
+        JSONAssert.assertEquals("JSON Result must equal!",
+            "{\"errorMessage\":\"Module [nonExistingModule] not found.\"}",
+            result.getResponse().getContentAsString(),
+            JSONCompareMode.LENIENT);
+    }
+
+    @Test
+    @WithMockUser(authorities = "WebServiceAdmin")
     public void moduleControl() throws Exception
     {
         RequestBuilder requestBuilder = MockMvcRequestBuilders.put("/rest/moduleControl")

--- a/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/event/service/ClusterEventBroadcastChannel.java
+++ b/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/event/service/ClusterEventBroadcastChannel.java
@@ -1,0 +1,28 @@
+package org.ikasan.spec.scheduled.event.service;
+
+import org.ikasan.spec.scheduled.event.service.ClusterEventService;
+
+/**
+ * Delivery channel for broadcasting cluster events to one remote dashboard node.
+ */
+public interface ClusterEventBroadcastChannel {
+
+    /**
+     * Submits a broadcast action to this remote node's delivery lane.
+     *
+     * @param task broadcast action to execute
+     */
+    void submit(Runnable task);
+
+    /**
+     * Returns the service used to publish events to this remote node.
+     *
+     * @return cluster event service
+     */
+    ClusterEventService service();
+
+    /**
+     * Releases channel resources.
+     */
+    void shutdown();
+}

--- a/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/job/service/SpringCloudConfigRefreshService.java
+++ b/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/job/service/SpringCloudConfigRefreshService.java
@@ -32,7 +32,13 @@ public interface SpringCloudConfigRefreshService {
     String encrypt(String valueToEncrypt);
 
     /**
-     * Service to run the Spring Actuator Refresh
+     * Service to run the Spring Actuator Refresh on this node.
      */
     void actuatorRefresh();
+
+    /**
+     * Service to run the Spring Actuator Refresh on a specific peer node URL.
+     * @param baseUrl base URL of the peer dashboard node (e.g. http://peer-host:9090)
+     */
+    void actuatorRefreshAtUrl(String baseUrl);
 }

--- a/ikasaneip/transaction/arjuna/pom.xml
+++ b/ikasaneip/transaction/arjuna/pom.xml
@@ -59,6 +59,16 @@
         <dependency>
             <groupId>me.snowdrop</groupId>
             <artifactId>narayana-spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.narayana.jta</groupId>
+                    <artifactId>narayana-jta</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-pool2</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/ikasaneip/version/src/main/java/org/ikasan/IkasanVersion.java
+++ b/ikasaneip/version/src/main/java/org/ikasan/IkasanVersion.java
@@ -20,30 +20,45 @@ public class IkasanVersion {
         String classPath = theClass.getResource(theClass.getSimpleName() + ".class").toString();
         logger.debug("Class: " + classPath);
 
-        // Find the path of the lib which includes the class
-        String libPath = classPath.substring(0, classPath.lastIndexOf("!"));
-        logger.debug("Lib:   " + libPath);
-
-        // Find the path of the file inside the lib jar
-        String filePath = libPath + "!/META-INF/MANIFEST.MF";
-        logger.debug("File:  " + filePath);
-
-        try {
-            // We look at the manifest file, getting two attributes out of it
-            Manifest manifest = new Manifest(new URL(filePath).openStream());
-            Attributes attr = manifest.getMainAttributes();
-            logger.debug("Implementation-Version: " + attr.getValue("Implementation-Version"));
-            if(attr.getValue("Implementation-Version") != null) {
-                IKASAN_VERSION = attr.getValue("Implementation-Version");
-            }
-            else {
-                logger.warn(String.format("Could not load manifest from from location [%s]. It appears that Implementation-Version is not available" +
-                    " in the manifest file!", libPath));
-            }
+        // The "!" only appears when the class was loaded out of a packaged jar (jar:file:...!/path/to/Class.class).
+        // In a Maven reactor build, a downstream module can instead resolve org.ikasan.spec.module.Module straight
+        // from an upstream module's target/classes directory (workspace resolution) rather than its installed jar,
+        // giving a plain file:/.../target/classes/... URL with no "!". That used to make lastIndexOf("!") return -1
+        // and substring(0, -1) throw a StringIndexOutOfBoundsException here in the static initialiser, which
+        // permanently poisons this class for the rest of the JVM (every later usage fails with
+        // NoClassDefFoundError) - seen intermittently depending on whether the build is a full reactor run or
+        // resumed with -rf from a later module. Guard it instead of assuming a jar is always involved.
+        int jarSeparatorIndex = classPath.lastIndexOf("!");
+        if (jarSeparatorIndex < 0) {
+            logger.debug("Class [{}] was not loaded from a jar (no manifest to read); leaving version as [{}]",
+                classPath, IKASAN_VERSION);
         }
-        catch (Exception e) {
-            logger.warn(String.format("Could not load manifest from from location [%s] due to exception [%s]"
-                , libPath, e.getMessage()), e);
+        else {
+            // Find the path of the lib which includes the class
+            String libPath = classPath.substring(0, jarSeparatorIndex);
+            logger.debug("Lib:   " + libPath);
+
+            // Find the path of the file inside the lib jar
+            String filePath = libPath + "!/META-INF/MANIFEST.MF";
+            logger.debug("File:  " + filePath);
+
+            try {
+                // We look at the manifest file, getting two attributes out of it
+                Manifest manifest = new Manifest(new URL(filePath).openStream());
+                Attributes attr = manifest.getMainAttributes();
+                logger.debug("Implementation-Version: " + attr.getValue("Implementation-Version"));
+                if(attr.getValue("Implementation-Version") != null) {
+                    IKASAN_VERSION = attr.getValue("Implementation-Version");
+                }
+                else {
+                    logger.warn(String.format("Could not load manifest from from location [%s]. It appears that Implementation-Version is not available" +
+                        " in the manifest file!", libPath));
+                }
+            }
+            catch (Exception e) {
+                logger.warn(String.format("Could not load manifest from from location [%s] due to exception [%s]"
+                    , libPath, e.getMessage()), e);
+            }
         }
     }
     public static String getVersion() {


### PR DESCRIPTION
The main purpose of this PR is ClusterEventBroadcastChannel, which is used by the ikasan-dashboard as part of the IKASAN-2707 work to ultimately support multiple dashboards in a cluster.

There were also a few minor tweaks to tests to prevent recurring build testing issues. There is a workaround i.e. restart the test suite from the point where it crashed.