### PR TITLE
IKASAN-2756 Core changes to allow JobPlan substitution for archive di…

### DIFF
--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/broker/MoveFileBroker.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/broker/MoveFileBroker.java
@@ -7,6 +7,10 @@ import org.ikasan.spec.component.endpoint.Broker;
 import org.ikasan.spec.component.endpoint.EndpointException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
@@ -17,6 +21,9 @@ public class MoveFileBroker implements Broker<FileWatcherJobEvent, FileWatcherJo
     private static Logger logger = LoggerFactory.getLogger(MoveFileBroker.class);
     public static SimpleDateFormat ARCHIVE_FILE_DATE_FORMATTER = new SimpleDateFormat("YYYYddMM_hhmmss");
 
+    public static final String MOVE_DIRECTORY_PATTERN = "moveDirectoryPattern";
+    public static final String CORRELATING_IDENTIFIER = "correlatingIdentifier";
+
     @Override
     public FileWatcherJobEvent invoke(FileWatcherJobEvent fileWatcherJobEvent) throws EndpointException {
         if(fileWatcherJobEvent.isDryRun()) {
@@ -25,15 +32,17 @@ public class MoveFileBroker implements Broker<FileWatcherJobEvent, FileWatcherJo
 
         if(fileWatcherJobEvent.getCorrelatedFileList() != null && fileWatcherJobEvent.getCorrelatedFileList().getFileList() != null) {
             try {
+                String moveDirectory = this.resolveMoveDirectory(fileWatcherJobEvent);
+
                 for (File file : fileWatcherJobEvent.getCorrelatedFileList().getFileList()) {
-                    if (fileWatcherJobEvent.getMoveDirectory() != null && !fileWatcherJobEvent.getMoveDirectory().isEmpty()
-                        && !fileWatcherJobEvent.getMoveDirectory().equals(".")) {
-                        logger.info(String.format("Moving file[%s] to directory[%s]", file.getAbsolutePath(), fileWatcherJobEvent.getMoveDirectory()));
-                        File destDir = new File(fileWatcherJobEvent.getMoveDirectory());
+                    if (moveDirectory != null && !moveDirectory.isEmpty()
+                        && !moveDirectory.equals(".")) {
+                        logger.info(String.format("Moving file[%s] to directory[%s]", file.getAbsolutePath(), moveDirectory));
+                        File destDir = new File(moveDirectory);
 
                         if (file.getParentFile().equals(destDir)) {
                             logger.info(String.format("Not moving file[%s] to directory[%s], as the source and destination directories are the same!"
-                                , file.getAbsolutePath(), fileWatcherJobEvent.getMoveDirectory()));
+                                , file.getAbsolutePath(), moveDirectory));
                         } else {
                             File destFile = new File(destDir, file.getName());
                             if (destFile.exists()) {
@@ -50,6 +59,32 @@ public class MoveFileBroker implements Broker<FileWatcherJobEvent, FileWatcherJo
         }
 
         return fileWatcherJobEvent;
+    }
+
+    /**
+     * Resolve the actual move (archive) directory to use, evaluating the configured SpEL expression
+     * against the raw moveDirectory pattern when one has been configured. Falls back to the raw
+     * moveDirectory value unchanged when no SpEL expression is configured, for backward compatibility
+     * with existing jobs.
+     *
+     * @param fileWatcherJobEvent the event carrying the raw moveDirectory and optional SpEL expression
+     * @return the resolved move directory
+     */
+    private String resolveMoveDirectory(FileWatcherJobEvent fileWatcherJobEvent) {
+        String moveDirectory = fileWatcherJobEvent.getMoveDirectory();
+
+        if (fileWatcherJobEvent.getMoveDirectorySpelExpression() != null) {
+            StandardEvaluationContext evaluationContext = new StandardEvaluationContext();
+            evaluationContext.setVariable(MOVE_DIRECTORY_PATTERN, fileWatcherJobEvent.getMoveDirectory());
+            evaluationContext.setVariable(CORRELATING_IDENTIFIER, fileWatcherJobEvent.getCorrelationIdentifier());
+
+            ExpressionParser parser = new SpelExpressionParser();
+            Expression exp = parser.parseExpression(fileWatcherJobEvent.getMoveDirectorySpelExpression());
+
+            moveDirectory = exp.getValue(evaluationContext, String.class);
+        }
+
+        return moveDirectory;
     }
 
     /**

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/converter/JobExecutionContextToFileWatcherJobConverter.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/converter/JobExecutionContextToFileWatcherJobConverter.java
@@ -34,6 +34,7 @@ public class JobExecutionContextToFileWatcherJobConverter implements Converter<J
         fileWatcherJobEvent.setContextName(this.configuration.getContextName());
         fileWatcherJobEvent.setJobName(this.configuration.getJobName());
         fileWatcherJobEvent.setMoveDirectory(this.configuration.getMoveDirectory());
+        fileWatcherJobEvent.setMoveDirectorySpelExpression(this.configuration.getMoveDirectorySpelExpression());
         fileWatcherJobEvent.setFilename(this.configuration.getFilename());
         fileWatcherJobEvent.setFilePath(this.configuration.getFilePath());
         fileWatcherJobEvent.setMinFileAgeSeconds(this.configuration.getMinFileAgeSeconds());

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/converter/configuration/FileWatcherJobConverterConfiguration.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/component/converter/configuration/FileWatcherJobConverterConfiguration.java
@@ -13,6 +13,7 @@ public class FileWatcherJobConverterConfiguration {
     private String fileNameSpelExpression;
     private String filePathSpelExpression;
     private String moveDirectory;
+    private String moveDirectorySpelExpression;
     private int minFileAgeSeconds;
     /** cron expression on expected time of file availability */
     private String slaCronExpression;
@@ -90,6 +91,14 @@ public class FileWatcherJobConverterConfiguration {
 
     public void setMoveDirectory(String moveDirectory) {
         this.moveDirectory = moveDirectory;
+    }
+
+    public String getMoveDirectorySpelExpression() {
+        return moveDirectorySpelExpression;
+    }
+
+    public void setMoveDirectorySpelExpression(String moveDirectorySpelExpression) {
+        this.moveDirectorySpelExpression = moveDirectorySpelExpression;
     }
 
     public int getMinFileAgeSeconds() {

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/model/FileWatcherJobEvent.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/model/FileWatcherJobEvent.java
@@ -19,6 +19,7 @@ public class FileWatcherJobEvent implements Serializable {
     private String fileNameSpelExpression;
     private String filePathSpelExpression;
     private String moveDirectory;
+    private String moveDirectorySpelExpression;
     private int minFileAgeSeconds = 0;
     /** cron expression on expected time of file availability */
     private String slaCronExpression;
@@ -103,6 +104,14 @@ public class FileWatcherJobEvent implements Serializable {
 
     public void setMoveDirectory(String moveDirectory) {
         this.moveDirectory = moveDirectory;
+    }
+
+    public String getMoveDirectorySpelExpression() {
+        return moveDirectorySpelExpression;
+    }
+
+    public void setMoveDirectorySpelExpression(String moveDirectorySpelExpression) {
+        this.moveDirectorySpelExpression = moveDirectorySpelExpression;
     }
 
     public int getMinFileAgeSeconds() {
@@ -213,6 +222,7 @@ public class FileWatcherJobEvent implements Serializable {
             .add("fileNameSpelExpression='" + fileNameSpelExpression + "'")
             .add("filePathSpelExpression='" + filePathSpelExpression + "'")
             .add("moveDirectory='" + moveDirectory + "'")
+            .add("moveDirectorySpelExpression='" + moveDirectorySpelExpression + "'")
             .add("minFileAgeSeconds=" + minFileAgeSeconds)
             .add("slaCronExpression='" + slaCronExpression + "'")
             .add("timeZone='" + timeZone + "'")
@@ -242,6 +252,7 @@ public class FileWatcherJobEvent implements Serializable {
             && Objects.equals(fileNameSpelExpression, that.fileNameSpelExpression)
             && Objects.equals(filePathSpelExpression, that.filePathSpelExpression)
             && Objects.equals(moveDirectory, that.moveDirectory)
+            && Objects.equals(moveDirectorySpelExpression, that.moveDirectorySpelExpression)
             && Objects.equals(slaCronExpression, that.slaCronExpression)
             && Objects.equals(timeZone, that.timeZone)
             && Objects.equals(blackoutWindowCronExpressions, that.blackoutWindowCronExpressions)
@@ -255,7 +266,7 @@ public class FileWatcherJobEvent implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(contextName, jobName, childContextNames, correlationIdentifier, filePath
-            , filename, fileNameSpelExpression, filePathSpelExpression, moveDirectory, minFileAgeSeconds
+            , filename, fileNameSpelExpression, filePathSpelExpression, moveDirectory, moveDirectorySpelExpression, minFileAgeSeconds
             , slaCronExpression, timeZone, blackoutWindowCronExpressions, blackoutWindowDateTimeRanges
             , correlatedFileList, fireTime, nextFireTime, jobGroup, jobDescription, dryRun, outcome);
     }

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/service/JobProvisionServiceImpl.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/main/java/org/ikasan/ootb/scheduler/agent/module/service/JobProvisionServiceImpl.java
@@ -551,6 +551,7 @@ public class JobProvisionServiceImpl implements JobProvisionService {
         fileConsumerConfiguration.setContextName(job.getContextName());
         fileConsumerConfiguration.setJobName(job.getJobName());
         fileConsumerConfiguration.setMoveDirectory(job.getMoveDirectory());
+        fileConsumerConfiguration.setMoveDirectorySpelExpression(job.getMoveDirectorySpel());
         if(job.getFilenames() != null && job.getFilenames().size() > 0) {
             fileConsumerConfiguration.setFilename(job.getFilenames().get(0));
         }

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/test/java/org/ikasan/ootb/scheduler/agent/module/component/broker/MoveFileBrokerTest.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/test/java/org/ikasan/ootb/scheduler/agent/module/component/broker/MoveFileBrokerTest.java
@@ -6,7 +6,9 @@ import org.ikasan.ootb.scheduler.agent.module.component.broker.exception.MoveFil
 import org.ikasan.ootb.scheduler.agent.module.model.FileWatcherJobEvent;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -17,23 +19,25 @@ import java.util.List;
 @RunWith(MockitoJUnitRunner.class)
 public class MoveFileBrokerTest {
 
-    @Before
-    public void createArchiveDirectory() throws IOException {
-        File archiveDirectory = new File("src/test/resources/data/archive");
-        if (!archiveDirectory.exists()) {
-            archiveDirectory.mkdirs();
-        }
+    // Each test gets its own throwaway TemporaryFolder directory, since each test is moving files
+    // around, this makes it safe to run the tests concurrently should we decide to. The TempFolder
+    // is automatically delete after the test.
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
-        if(new File("src/test/resources/data/archive/test.txt").exists()) {
-            FileUtils.moveFileToDirectory(new File("src/test/resources/data/archive/test.txt")
-                , new File("src/test/resources/data"), true);
-        }
-        FileUtils.cleanDirectory(new File("src/test/resources/data/archive"));
+    private File sourceFile;
+    private File archiveDir;
+
+    @Before
+    public void setUp() throws IOException {
+        sourceFile = tempFolder.newFile("test.txt");
+        archiveDir = new File(tempFolder.getRoot(), "archive");
+        archiveDir.mkdirs();
     }
 
     @Test
     public void test_move_file_success() throws IOException {
-       List<File> files = List.of(new File("src/test/resources/data/test.txt"));
+        List<File> files = List.of(sourceFile);
 
         MoveFileBroker broker = new MoveFileBroker();
 
@@ -44,19 +48,19 @@ public class MoveFileBrokerTest {
         event.setCorrelatedFileList(correlatedFileList);
         event.setJobName("jobName");
         event.setMinFileAgeSeconds(30);
-        event.setMoveDirectory("src/test/resources/data/archive");
+        event.setMoveDirectory(archiveDir.getAbsolutePath());
         event.setJobName("jobName");
 
         broker.invoke(event);
 
-        String[] archiveFiles = new File("src/test/resources/data/archive").list();
+        String[] archiveFiles = archiveDir.list();
 
         Assert.assertEquals("test.txt", archiveFiles[0]);
     }
 
     @Test
     public void test_same_file_twice_move_file_success() throws IOException {
-        List<File> files = List.of(new File("src/test/resources/data/test.txt"));
+        List<File> files = List.of(sourceFile);
 
         MoveFileBroker broker = new MoveFileBroker();
 
@@ -67,28 +71,27 @@ public class MoveFileBrokerTest {
         event.setCorrelatedFileList(correlatedFileList);
         event.setJobName("jobName");
         event.setMinFileAgeSeconds(30);
-        event.setMoveDirectory("src/test/resources/data/archive");
+        event.setMoveDirectory(archiveDir.getAbsolutePath());
         event.setJobName("jobName");
 
         broker.invoke(event);
 
-        String[] archiveFiles = new File("src/test/resources/data/archive").list();
+        String[] archiveFiles = archiveDir.list();
 
         Assert.assertEquals("test.txt", archiveFiles[0]);
 
-        FileUtils.copyFileToDirectory(new File("src/test/resources/data/archive/test.txt")
-            , new File("src/test/resources/data"), true);
+        FileUtils.copyFileToDirectory(new File(archiveDir, "test.txt"), tempFolder.getRoot(), true);
 
         broker.invoke(event);
 
-        archiveFiles = new File("src/test/resources/data/archive").list();
+        archiveFiles = archiveDir.list();
 
         Assert.assertEquals(2, archiveFiles.length);
     }
 
     @Test
     public void test_move_file_dry_run_success() {
-        List<File> files = List.of(new File("src/test/resources/data/test.txt"));
+        List<File> files = List.of(sourceFile);
 
         MoveFileBroker broker = new MoveFileBroker();
 
@@ -99,20 +102,20 @@ public class MoveFileBrokerTest {
         event.setCorrelatedFileList(correlatedFileList);
         event.setJobName("jobName");
         event.setMinFileAgeSeconds(30);
-        event.setMoveDirectory("src/test/resources/data/archive");
+        event.setMoveDirectory(archiveDir.getAbsolutePath());
         event.setJobName("jobName");
         event.setDryRun(true);
 
         broker.invoke(event);
 
-        String[] archiveFiles = new File("src/test/resources/data/archive").list();
+        String[] archiveFiles = archiveDir.list();
 
         Assert.assertEquals(0, archiveFiles.length);
     }
 
     @Test
     public void test_move_file_job_dry_run_success() {
-        List<File> files = List.of(new File("src/test/resources/data/test.txt"));
+        List<File> files = List.of(sourceFile);
 
         MoveFileBroker broker = new MoveFileBroker();
 
@@ -123,20 +126,20 @@ public class MoveFileBrokerTest {
         event.setCorrelatedFileList(correlatedFileList);
         event.setJobName("jobName");
         event.setMinFileAgeSeconds(30);
-        event.setMoveDirectory("src/test/resources/data/archive");
+        event.setMoveDirectory(archiveDir.getAbsolutePath());
         event.setJobName("jobName");
         event.setDryRun(true);
 
         broker.invoke(event);
 
-        String[] archiveFiles = new File("src/test/resources/data/archive").list();
+        String[] archiveFiles = archiveDir.list();
 
         Assert.assertEquals(0, archiveFiles.length);
     }
 
     @Test
     public void test_move_file_dry_run_move_directory_same_as_src_directory() throws IOException {
-        List<File> files = List.of(new File("src/test/resources/data/test.txt"));
+        List<File> files = List.of(sourceFile);
 
         MoveFileBroker broker = new MoveFileBroker();
 
@@ -147,19 +150,19 @@ public class MoveFileBrokerTest {
         event.setCorrelatedFileList(correlatedFileList);
         event.setJobName("jobName");
         event.setMinFileAgeSeconds(30);
-        event.setMoveDirectory("src/test/resources/data/");
+        event.setMoveDirectory(tempFolder.getRoot().getAbsolutePath());
         event.setJobName("jobName");
 
         broker.invoke(event);
 
-        String[] archiveFiles = new File("src/test/resources/data/archive").list();
+        String[] archiveFiles = archiveDir.list();
 
         Assert.assertEquals(0, archiveFiles.length);
     }
 
     @Test
     public void test_move_file_dry_run_move_directory_same_as_src_directory_due_to_dot() throws IOException {
-        List<File> files = List.of(new File("src/test/resources/data/test.txt"));
+        List<File> files = List.of(sourceFile);
 
         MoveFileBroker broker = new MoveFileBroker();
 
@@ -175,14 +178,14 @@ public class MoveFileBrokerTest {
 
         broker.invoke(event);
 
-        String[] archiveFiles = new File("src/test/resources/data/archive").list();
+        String[] archiveFiles = archiveDir.list();
 
         Assert.assertEquals(0, archiveFiles.length);
     }
 
     @Test
     public void test_move_no_target_dir_success() throws IOException {
-        List<File> files = List.of(new File("src/test/resources/data/test.txt"));
+        List<File> files = List.of(sourceFile);
 
         MoveFileBroker broker = new MoveFileBroker();
 
@@ -197,14 +200,14 @@ public class MoveFileBrokerTest {
 
         broker.invoke(event);
 
-        String[] archiveFiles = new File("src/test/resources/data/archive").list();
+        String[] archiveFiles = archiveDir.list();
 
         Assert.assertEquals(0, archiveFiles.length);
     }
 
     @Test(expected = MoveFileBrokerException.class)
     public void test_exception_bad_tgt_directory() {
-        List<File> files = List.of(new File("src/test/resources/data/test.txt"));
+        List<File> files = List.of(sourceFile);
 
         MoveFileBroker broker = new MoveFileBroker();
 
@@ -222,6 +225,151 @@ public class MoveFileBrokerTest {
         broker.invoke(event);
     }
 
+    @Test
+    public void test_move_file_with_spel_expression_success() throws IOException {
+        List<File> files = List.of(sourceFile);
+
+        MoveFileBroker broker = new MoveFileBroker();
+
+        CorrelatedFileList correlatedFileList = new CorrelatedFileList(files, "correlationIdentifier");
+
+        String moveDirectoryPattern = new File(tempFolder.getRoot(), "{token}").getAbsolutePath();
+
+        FileWatcherJobEvent event = new FileWatcherJobEvent();
+        event.setCorrelationIdentifier("correlationIdentifier");
+        event.setCorrelatedFileList(correlatedFileList);
+        event.setJobName("jobName");
+        event.setMinFileAgeSeconds(30);
+        event.setMoveDirectory(moveDirectoryPattern);
+        event.setMoveDirectorySpelExpression("#moveDirectoryPattern.replace('{token}', 'archive')");
+        event.setJobName("jobName");
+
+        broker.invoke(event);
+
+        Assert.assertEquals(moveDirectoryPattern, event.getMoveDirectory());
+
+        String[] archiveFiles = archiveDir.list();
+
+        Assert.assertEquals("test.txt", archiveFiles[0]);
+    }
+
+    @Test
+    public void test_move_file_with_spel_expression_using_correlating_identifier() throws IOException {
+        List<File> files = List.of(sourceFile);
+
+        MoveFileBroker broker = new MoveFileBroker();
+
+        CorrelatedFileList correlatedFileList = new CorrelatedFileList(files, "correlationIdentifier");
+
+        String moveDirectoryPattern = new File(tempFolder.getRoot(), "{token}").getAbsolutePath();
+
+        FileWatcherJobEvent event = new FileWatcherJobEvent();
+        event.setCorrelationIdentifier("archive");
+        event.setCorrelatedFileList(correlatedFileList);
+        event.setJobName("jobName");
+        event.setMinFileAgeSeconds(30);
+        event.setMoveDirectory(moveDirectoryPattern);
+        event.setMoveDirectorySpelExpression("#moveDirectoryPattern.replace('{token}', #correlatingIdentifier)");
+        event.setJobName("jobName");
+
+        broker.invoke(event);
+
+        String[] archiveFiles = archiveDir.list();
+
+        Assert.assertEquals("test.txt", archiveFiles[0]);
+    }
+
+    @Test
+    public void test_move_file_with_conditional_spel_expression_success() throws IOException {
+        List<File> files = List.of(sourceFile);
+
+        MoveFileBroker broker = new MoveFileBroker();
+
+        CorrelatedFileList correlatedFileList = new CorrelatedFileList(files, "correlationIdentifier");
+
+        String moveDirectoryPattern = new File(tempFolder.getRoot(), "{token}").getAbsolutePath();
+
+        FileWatcherJobEvent event = new FileWatcherJobEvent();
+        event.setCorrelationIdentifier("correlationIdentifier");
+        event.setCorrelatedFileList(correlatedFileList);
+        event.setJobName("jobName");
+        event.setMinFileAgeSeconds(30);
+        event.setMoveDirectory(moveDirectoryPattern);
+        event.setMoveDirectorySpelExpression("#moveDirectoryPattern.contains('{token}') ? #moveDirectoryPattern.replace('{token}', 'archive') " +
+            ": (#moveDirectoryPattern.contains('{other}') ? #moveDirectoryPattern.replace('{other}', 'archive') : #moveDirectoryPattern)");
+        event.setJobName("jobName");
+
+        broker.invoke(event);
+
+        String[] archiveFiles = archiveDir.list();
+
+        Assert.assertEquals("test.txt", archiveFiles[0]);
+    }
+
+    @Test
+    public void test_move_file_with_conditional_spel_expression_no_replacement() throws IOException {
+        List<File> files = List.of(sourceFile);
+
+        MoveFileBroker broker = new MoveFileBroker();
+
+        CorrelatedFileList correlatedFileList = new CorrelatedFileList(files, "correlationIdentifier");
+
+        FileWatcherJobEvent event = new FileWatcherJobEvent();
+        event.setCorrelationIdentifier("correlationIdentifier");
+        event.setCorrelatedFileList(correlatedFileList);
+        event.setJobName("jobName");
+        event.setMinFileAgeSeconds(30);
+        event.setMoveDirectory(archiveDir.getAbsolutePath());
+        event.setMoveDirectorySpelExpression("#moveDirectoryPattern.contains('{token}') ? #moveDirectoryPattern.replace('{token}', 'archive') " +
+            ": (#moveDirectoryPattern.contains('{other}') ? #moveDirectoryPattern.replace('{other}', 'archive') : #moveDirectoryPattern)");
+        event.setJobName("jobName");
+
+        broker.invoke(event);
+
+        Assert.assertEquals(archiveDir.getAbsolutePath(), event.getMoveDirectory());
+
+        String[] archiveFiles = archiveDir.list();
+
+        Assert.assertEquals("test.txt", archiveFiles[0]);
+    }
+
+    @Test
+    public void test_move_file_with_spel_expression_multiple_invocations_with_changed_correlating_identifier() throws IOException {
+        List<File> files = List.of(sourceFile);
+
+        MoveFileBroker broker = new MoveFileBroker();
+
+        CorrelatedFileList correlatedFileList = new CorrelatedFileList(files, "correlationIdentifier");
+
+        FileWatcherJobEvent event = new FileWatcherJobEvent();
+        event.setCorrelationIdentifier("first");
+        event.setCorrelatedFileList(correlatedFileList);
+        event.setJobName("jobName");
+        event.setMinFileAgeSeconds(30);
+        event.setMoveDirectory(new File(archiveDir, "{token}").getAbsolutePath());
+        event.setMoveDirectorySpelExpression("#moveDirectoryPattern.replace('{token}', #correlatingIdentifier)");
+        event.setJobName("jobName");
+
+        broker.invoke(event);
+
+        File firstArchiveDir = new File(archiveDir, "first");
+        Assert.assertTrue(firstArchiveDir.exists());
+        Assert.assertEquals("test.txt", firstArchiveDir.list()[0]);
+
+        FileUtils.copyFileToDirectory(new File(firstArchiveDir, "test.txt"), tempFolder.getRoot(), true);
+
+        event.setCorrelationIdentifier("second");
+
+        broker.invoke(event);
+
+        File secondArchiveDir = new File(archiveDir, "second");
+        Assert.assertTrue(secondArchiveDir.exists());
+        Assert.assertEquals("test.txt", secondArchiveDir.list()[0]);
+
+        // first invocation's file untouched by the second invocation, proving the SpEL was re-resolved per-call rather than cached
+        Assert.assertEquals("test.txt", firstArchiveDir.list()[0]);
+    }
+
     @Test(expected = MoveFileBrokerException.class)
     public void test_exception_bad_src_file() throws IOException {
         List<File> files = List.of(new File("///\\\\////\\\\BAD FILE PATH/test.txt"));
@@ -235,13 +383,10 @@ public class MoveFileBrokerTest {
         event.setCorrelatedFileList(correlatedFileList);
         event.setJobName("jobName");
         event.setMinFileAgeSeconds(30);
-        event.setMoveDirectory("src/test/resources/data/archive");
+        event.setMoveDirectory(archiveDir.getAbsolutePath());
         event.setJobName("jobName");
 
         broker.invoke(event);
-
-        String[] archiveFiles = new File("src/test/resources/data/archive").list();
-
-        Assert.assertEquals("test.txt", archiveFiles[0]);
+        // MoveFileBrokerException thown by above call so no further assertions.
     }
 }

--- a/ikasaneip/ootb/module/scheduler-agent/jar/src/test/java/org/ikasan/ootb/scheduler/agent/module/service/JobProvisionServiceImplTest.java
+++ b/ikasaneip/ootb/module/scheduler-agent/jar/src/test/java/org/ikasan/ootb/scheduler/agent/module/service/JobProvisionServiceImplTest.java
@@ -202,6 +202,7 @@ public class JobProvisionServiceImplTest {
         verify(fileWatcherJobConverterConfiguration, times(1)).setFilePathSpelExpression(anyString());
         verify(fileWatcherJobConverterConfiguration, times(1)).setContextName(anyString());
         verify(fileWatcherJobConverterConfiguration, times(1)).setMoveDirectory(anyString());
+        verify(fileWatcherJobConverterConfiguration, times(1)).setMoveDirectorySpelExpression(anyString());
         verify(fileWatcherJobConverterConfiguration, times(1)).setMinFileAgeSeconds(anyInt());
         verify(fileWatcherJobConverterConfiguration, times(1)).setChildContextNames(any());
         verify(fileWatcherJobConverterConfiguration, times(1)).setBlackoutWindowCronExpressions(any());
@@ -402,6 +403,7 @@ public class JobProvisionServiceImplTest {
         verify(fileWatcherJobConverterConfiguration, times(1)).setFilePathSpelExpression(anyString());
         verify(fileWatcherJobConverterConfiguration, times(1)).setContextName(anyString());
         verify(fileWatcherJobConverterConfiguration, times(1)).setMoveDirectory(anyString());
+        verify(fileWatcherJobConverterConfiguration, times(1)).setMoveDirectorySpelExpression(anyString());
         verify(fileWatcherJobConverterConfiguration, times(1)).setMinFileAgeSeconds(anyInt());
         verify(fileWatcherJobConverterConfiguration, times(1)).setChildContextNames(any());
         verify(fileWatcherJobConverterConfiguration, times(1)).setBlackoutWindowCronExpressions(any());
@@ -623,6 +625,7 @@ public class JobProvisionServiceImplTest {
         fileEventDrivenJob.setDynamic(true);
         fileEventDrivenJob.setFilenameSpel("filename spel");
         fileEventDrivenJob.setFilePathSpel("file path spel");
+        fileEventDrivenJob.setMoveDirectorySpel("move directory spel");
         fileEventDrivenJob.setSlaCronExpression("sla cron expression");
 
         QuartzScheduleDrivenJobImpl quartzScheduleDrivenJob = new QuartzScheduleDrivenJobImpl();

--- a/ikasaneip/ootb/rest/scheduler-agent-rest-module/src/main/java/org/ikasan/job/orchestration/model/job/FileEventDrivenJobImpl.java
+++ b/ikasaneip/ootb/rest/scheduler-agent-rest-module/src/main/java/org/ikasan/job/orchestration/model/job/FileEventDrivenJobImpl.java
@@ -49,6 +49,8 @@ public class FileEventDrivenJobImpl extends QuartzScheduleDrivenJobImpl implemen
 
     private Set<ReplacementPair> filenameReplacementPairs;
     private Set<ReplacementPair> filePathReplacementPairs;
+    private String moveDirectorySpel;
+    private Set<ReplacementPair> moveDirectoryReplacementPairs;
 
     @Override
     public String getFilePath() {
@@ -231,6 +233,26 @@ public class FileEventDrivenJobImpl extends QuartzScheduleDrivenJobImpl implemen
     }
 
     @Override
+    public String getMoveDirectorySpel() {
+        return moveDirectorySpel;
+    }
+
+    @Override
+    public void setMoveDirectorySpel(String moveDirectorySpel) {
+        this.moveDirectorySpel = moveDirectorySpel;
+    }
+
+    @Override
+    public Set<ReplacementPair> getMoveDirectoryReplacementPairs() {
+        return moveDirectoryReplacementPairs;
+    }
+
+    @Override
+    public void setMoveDirectoryReplacementPairs(Set<ReplacementPair> moveDirectoryReplacementPairs) {
+        this.moveDirectoryReplacementPairs = moveDirectoryReplacementPairs;
+    }
+
+    @Override
     public String toString() {
         final StringBuffer sb = new StringBuffer("FileEventDrivenJobImpl{");
         sb.append("filePath='").append(filePath).append('\'');
@@ -247,6 +269,7 @@ public class FileEventDrivenJobImpl extends QuartzScheduleDrivenJobImpl implemen
         sb.append(", isDynamic=").append(isDynamic);
         sb.append(", filePathSpel=").append(filePathSpel);
         sb.append(", filenameSpel=").append(filenameSpel);
+        sb.append(", moveDirectorySpel=").append(moveDirectorySpel);
         sb.append('}');
         return sb.toString();
     }

--- a/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/job/model/FileEventDrivenJob.java
+++ b/ikasaneip/spec/service/scheduled/src/main/java/org/ikasan/spec/scheduled/job/model/FileEventDrivenJob.java
@@ -254,4 +254,34 @@ public interface FileEventDrivenJob extends QuartzScheduleDrivenJob {
      * @param filePathReplacementPairs The list of ReplacementPair objects containing the replacement token and job plan parameter name.
      */
     void setFilePathReplacementPairs(Set<ReplacementPair> filePathReplacementPairs);
+
+    /**
+     * Get the SpEL expression for determining the move (archive) directory.
+     *
+     * @return the SpEL expression for determining the move directory
+     */
+    String getMoveDirectorySpel();
+
+    /**
+     * Set the Spring Expression Language (SpEL) for determining the move (archive) directory.
+     * This SpEL expression will be evaluated to fetch the move directory at runtime.
+     *
+     * @param moveDirectorySpel the SpEL expression for move directory
+     */
+    void setMoveDirectorySpel(String moveDirectorySpel);
+
+    /**
+     * Retrieves the list of ReplacementPair objects representing the move directory replacement pairs for the job.
+     *
+     * @return Set of ReplacementPair objects containing the replacement token and job plan parameter name.
+     */
+    Set<ReplacementPair> getMoveDirectoryReplacementPairs();
+
+    /**
+     * Set the list of ReplacementPair objects representing the move directory replacement pairs for the job.
+     * These ReplacementPair objects contain the replacement token and job plan parameter name
+     *
+     * @param moveDirectoryReplacementPairs The set of ReplacementPair objects containing the replacement token and job plan parameter name.
+     */
+    void setMoveDirectoryReplacementPairs(Set<ReplacementPair> moveDirectoryReplacementPairs);
 }


### PR DESCRIPTION
Core changes to allow JobPlan parameter substitution in the File watcher archive property. This PR will need to be merged before the dashboard work due to core dependencies. This was rebased onto 4.1.x